### PR TITLE
Include scopes in AuthOptions

### DIFF
--- a/modules/earthengine-layers/src/login/google-login-provider.js
+++ b/modules/earthengine-layers/src/login/google-login-provider.js
@@ -328,6 +328,7 @@ function getAuthOptionsFromProps(props) {
     client_id: props.clientId,
     cookie_policy: props.cookiePolicy,
     login_hint: props.loginHint,
+    scope: props.scope,
     hosted_domain: props.hostedDomain,
     fetch_basic_profile: props.fetchBasicProfile,
     ux_mode: props.uxMode,


### PR DESCRIPTION
This includes the scopes in the `AuthOptions` object, which is then passed to `auth2Initialize`.
https://github.com/UnfoldedInc/earthengine-layers/blob/049777c2627c7fc9b36af179ffd0c931fb4616c7/modules/earthengine-layers/src/login/google-login-provider.js#L156-L157

I found this necessary as a new user for the scopes to become attached to my account.