### PR TITLE
Update @google/earthengine to ^0.1.217

### DIFF
--- a/examples/ee-demo/package.json
+++ b/examples/ee-demo/package.json
@@ -13,7 +13,7 @@
     "@deck.gl/geo-layers": "^8.1.1",
     "@deck.gl/layers": "^8.1.1",
     "@deck.gl/react": "^8.1.1",
-    "@google/earthengine": "^0.1.209",
+    "@google/earthengine": "^0.1.217",
     "@unfolded.gl/earthengine-layers": "^0.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/modules/earthengine-layers/package.json
+++ b/modules/earthengine-layers/package.json
@@ -15,7 +15,7 @@
     "build-rollup": "rollup --config"
   },
   "dependencies": {
-    "@google/earthengine": "^0.1.209",
+    "@google/earthengine": "^0.1.217",
     "@mapbox/sphericalmercator": "^1.1.0",
     "@math.gl/web-mercator": "3.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,7 +1022,7 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@google/earthengine@^0.1.209":
+"@google/earthengine@^0.1.217":
   version "0.1.217"
   resolved "https://registry.yarnpkg.com/@google/earthengine/-/earthengine-0.1.217.tgz#077a61286a2ca81d250ffab77d3a87f9b8a5e230"
   integrity sha512-CpIyccte1tKs06rLNuUmfan9HHSugoVVRk8vlxYyCqpFzGvxQB8pc83sduDVClrgQHdH5gyYJq2l1mJDLxjSEg==


### PR DESCRIPTION
Looking at the `yarn.lock`, it looks like `0.1.217` was already being used, because of the caret in `^0.1.209`.