### PR TITLE
Update ee auth from props.token

### DIFF
--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -56,7 +56,8 @@ export default class App extends React.Component {
     this.loggedIn = true;
 
     this.forceUpdate();
-    await this.eeApi.initialize(EE_CLIENT_ID); // Client id to your EE application
+    // Client id to your EE application
+    await this.eeApi.initialize({clientId: EE_CLIENT_ID});
 
     const eeImage = ee.Image('CGIAR/SRTM90_V4').serialize();
     this.setState({eeImage});

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -33,7 +33,7 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   async _updateToken(props, oldProps, changeFlags) {
-    if (!props.token || (props.token === oldProps.token)) {
+    if (!props.token || props.token === oldProps.token) {
       return;
     }
 

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -31,10 +31,10 @@ export default class EarthEngineLayer extends CompositeLayer {
     this.state = {};
   }
 
-  updateState({props, oldProps, changeFlags}) {
-    this._updateToken(props, oldProps, changeFlags);
+  async updateState({props, oldProps, changeFlags}) {
+    await this._updateToken(props, oldProps, changeFlags);
     this._updateEEObject(props, oldProps, changeFlags);
-    this._updateEEVisParams(props, oldProps, changeFlags);
+    await this._updateEEVisParams(props, oldProps, changeFlags);
   }
 
   async _updateToken(props, oldProps, changeFlags) {

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -1,7 +1,7 @@
 import {CompositeLayer} from '@deck.gl/core';
 import EnhancedTileLayer from './tile-layer/enhanced-tile-layer';
 import {BitmapLayer} from '@deck.gl/layers';
-import './ee-api'; // Promisify ee apis
+import EEApi from './ee-api'; // Promisify ee apis
 // import {load} from '@loaders.gl/core';
 // import {ImageLoader, getImageData} from '@loaders.gl/images';
 import {loadImageBitmap} from './image-utils/image-utils';
@@ -11,9 +11,12 @@ import SphericalMercator from '@mapbox/sphericalmercator';
 
 const merc = new SphericalMercator({size: 256});
 
+const eeApi = new EEApi();
+
 const defaultProps = {
   /*
   data: object,
+  token: string,
   visParams: object
   */
 };
@@ -24,8 +27,19 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   updateState({props, oldProps, changeFlags}) {
+    this._updateToken(props, oldProps, changeFlags);
     this._updateEEObject(props, oldProps, changeFlags);
     this._updateEEVisParams(props, oldProps, changeFlags);
+  }
+
+  async _updateToken(props, oldProps, changeFlags) {
+    if (!props.token || (props.token === oldProps.token)) {
+      return;
+    }
+
+    const {token} = props;
+    await eeApi.initialize({token});
+    this.setState({token});
   }
 
   _updateEEObject(props, oldProps, changeFlags) {

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -13,6 +13,9 @@ import SphericalMercator from '@mapbox/sphericalmercator';
 const merc = new SphericalMercator({size: 256});
 
 const eeApi = new EEApi();
+// Global access token, to allow single EE API initialization if using multiple
+// layers
+let accessToken;
 
 const defaultProps = {
   /*
@@ -35,13 +38,13 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   async _updateToken(props, oldProps, changeFlags) {
-    if (!props.token || props.token === oldProps.token) {
+    if (!props.token || props.token === accessToken) {
       return;
     }
 
     const {token} = props;
     await eeApi.initialize({token});
-    this.setState({token});
+    accessToken = token;
   }
 
   _updateEEObject(props, oldProps, changeFlags) {

--- a/modules/earthengine-layers/src/ee-api.js
+++ b/modules/earthengine-layers/src/ee-api.js
@@ -33,7 +33,7 @@ export default class EEApi {
     });
   }
 
-  // TODO keep? - From github test code
+  // Set short-lived Access Token directly
   setToken(token) {
     if (token) {
       ee.apiclient.setAuthToken('', 'Bearer', token, 3600, [], undefined, false);

--- a/modules/earthengine-layers/src/ee-api.js
+++ b/modules/earthengine-layers/src/ee-api.js
@@ -7,13 +7,17 @@ export default class EEApi {
     this.ee = ee;
   }
 
-  async initialize(clientId, token) {
-    await this.authenticateViaOuth(clientId);
+  async initialize({clientId, token}) {
+    if (token) {
+      this.setToken(token);
+    } else {
+      await this.authenticateViaOAuth(clientId);
+    }
     await this._initialize();
   }
 
   // Authenticate using an OAuth pop-up.
-  async authenticateViaOuth(clientId, extraScopes = null) {
+  async authenticateViaOAuth(clientId, extraScopes = null) {
     return await new Promise((resolve, reject) => {
       ee.data.authenticateViaOauth(
         clientId,


### PR DESCRIPTION
- Updates `EEApi.initialize` to take either a `clientId` or `token`; if `token` is provided it sets the token with `ee` directly. This could be renamed to `accessToken` if we wanted to be more clear that this is the short-lived OAuth token.
- Adds an `_updateToken` step which calls `initialize` with the token if the prop exists and has changed. The full `initialize` step might not need to be called again if it's previously happened and only the token has changed. You might be able to do just `setToken`, which might prevent an extra HTTP call, but I haven't tested this.

	The idea is that on the Python side, a class could keep track of when the access token expires, and automatically refresh the token and pass it to JS on the next layer call.

I tested this with a modification of `ee-demo/app.js`, where I commented out `this.loginProvider` in the constructor. It worked but it's not possible to have a static demo using a predefined short-lived access token.

Closes #15