### PR TITLE
Add Pydeck introduction notebook

### DIFF
--- a/examples/pydeck/Introduction.ipynb
+++ b/examples/pydeck/Introduction.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pydeck Earth Engine Introduction\n",
+    "\n",
+    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
+    "```\n",
+    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
+    "source activate pydeck-ee\n",
+    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
+    "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "```\n",
+    "then open Jupyter Notebook with `jupyter notebook`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now in a Python Jupyter Notebook, let's first import required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pydeck as pdk\n",
+    "import requests\n",
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
+    "\n",
+    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "ee.Authenticate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Authentication\n",
+    "\n",
+    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work.\n",
+    "\n",
+    "First run the standard Earth Engine initialization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A further token is necessary for use with Pydeck. Here we ping the Google OAuth2 API to retrieve that token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credentials = ee.data.get_persistent_credentials()\n",
+    "url = 'https://www.googleapis.com/oauth2/v4/token'\n",
+    "data = {\n",
+    "    'client_id': credentials.client_id,\n",
+    "    'client_secret': credentials.client_secret,\n",
+    "    'refresh_token': credentials.refresh_token,\n",
+    "    'grant_type': 'refresh_token'\n",
+    "}\n",
+    "r = requests.post(url, data=data)\n",
+    "access_token = r.json()['access_token']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`access_token` now holds a token that you can pass to the Pydeck Earth Engine layer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Map\n",
+    "\n",
+    "Next it's time to create a map. Here we create an `ee.Image` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = ee.Image('CGIAR/SRTM90_V4')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Image` object itself can't be passed as-is to Pydeck. To create an object that can be passed to Pydeck, call the `.serialize()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee_object = image.serialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the `EarthEngineLayer` isn't built in to Deck.gl, we need to tell Pydeck to load a custom layer extension. Pass a URL to the built `earthengine-layers` bundle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://cdn.jsdelivr.net/gh/kylebarron/earthengine-layers@dev/modules/earthengine-layers/dist/bundle.js'\n",
+    "pdk.settings.custom_libraries = [\n",
+    "    {\n",
+    "        \"libraryName\": \"EarthEngineLayerLibrary\",\n",
+    "        \"resourceUri\": url,\n",
+    "    }\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to create the Pydeck layer. Note that you must include the `token` and serialized `ee_object` here. Currently in Pydeck, you must wrap each string in quotes, so that Pydeck doesn't interpret the string as a function. Also, the character used to wrap the string must not appear in the string, so please use a literal `'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee_layer = pdk.Layer(\n",
+    "    \"EarthEngineLayer\",\n",
+    "    None,\n",
+    "    token=f\"'{access_token}'\",\n",
+    "    ee_object=f\"'{ee_object}'\",\n",
+    "    vis_params={\"min\": 0, \"max\": 255}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3c23e300d2c4e6ab00a774d57c02a70",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[ee_layer], \n",
+    "    initial_view_state=view_state)\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/pydeck/README.md
+++ b/examples/pydeck/README.md
@@ -1,0 +1,24 @@
+## Earth Engine Pydeck examples
+
+This folder contains examples for using Pydeck with Google Earth Engine.
+
+### Install
+
+To run the example notebooks locally, you need to install a few Python
+dependencies. A custom Conda environment is recommended. To create and enter the
+environment, and enable Pydeck with Jupyter Notebook run:
+
+```bash
+conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y
+source activate pydeck-ee
+jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck
+jupyter nbextension enable --sys-prefix --py pydeck
+```
+
+### Start a notebook
+
+Then to start a notebook, run:
+
+```bash
+jupyter notebook Introduction.ipynb
+```


### PR DESCRIPTION
This adds an example Jupyter notebook for use with Pydeck and the Earth Engine layer. (To view the rendered notebook, [click here](https://nbviewer.jupyter.org/github/kylebarron/earthengine-layers/blob/notebook-example/examples/pydeck/Introduction.ipynb)).

Notes:

- Right now the friction points are:
	- Ping the Google OAuth endpoint to get an access token
	- Add the custom layer library
	- EE object must be serialized
	- The serialized EE object must further be wrapped in a pair of _single_ quotes, so that Pydeck interprets it as a literal string. With current Pydeck, wrapping it in double quotes removes every internal double quote, and thus destroys the JSON.
- For now, I load the layer's bundle from a branch on my fork, including #18 . The output of the rollup bundle is currently ignored by Git. Should that be included in the repository? I suppose that once the layer is published to NPM, the url can point to a released bundle, instead of to Github.
- I don't think the map object result is saved in the notebook because it's an iframe. (Usually results of computations can be saved in the notebook). Even if it were saved, since the access token expires quickly, the map wouldn't load.
