### PR TITLE
Fix jsdelivr url in notebook example

### DIFF
--- a/examples/pydeck/Introduction.ipynb
+++ b/examples/pydeck/Introduction.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://cdn.jsdelivr.net/gh/kylebarron/earthengine-layers@dev/modules/earthengine-layers/dist/bundle.js'\n",
+    "url = 'https://cdn.jsdelivr.net/gh/UnfoldedInc/earthengine-layers@master/modules/earthengine-layers/dist/bundle.js'\n",
     "pdk.settings.custom_libraries = [\n",
     "    {\n",
     "        \"libraryName\": \"EarthEngineLayerLibrary\",\n",
@@ -215,7 +215,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f3c23e300d2c4e6ab00a774d57c02a70",
+       "model_id": "d1ef9c5543d24d14a952164b4c76631f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -231,7 +231,8 @@
     "view_state = pdk.ViewState(latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45)\n",
     "r = pdk.Deck(\n",
     "    layers=[ee_layer], \n",
-    "    initial_view_state=view_state)\n",
+    "    initial_view_state=view_state\n",
+    ")\n",
     "r.show()"
    ]
   },
@@ -266,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This sets the notebook example to use new bundle on `master`, which includes #21 . 

This is tested with a new Python environment, as described [here](https://github.com/UnfoldedInc/earthengine-layers/blob/master/examples/pydeck/README.md), and works successfully.