### PR TITLE
Include notebook checkpoints in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ package-lock.json
 *.rar
 *.log
 .exit_code
+
+# Jupyter Notebook
+.ipynb_checkpoints


### PR DESCRIPTION
`.ipynb_checkpoints` are auto-generated files by Jupyter when autosaving. It's [ standard](https://github.com/github/gitignore/blob/2a4de265d37eca626309d8e115218d18985b5435/Python.gitignore#L78-L80) to have in a gitignore.