### PR TITLE
Python wrapper for Earth Engine Pydeck layer

### DIFF
--- a/py/.gitignore
+++ b/py/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0 (2020-04-23)
+
+- First release on PyPI.

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 (2020-04-27)
+
+- Include `requirements.txt` and `requirements_dev.txt` in `MANIFEST.in` to fix install.
+
 ## 0.1.0 (2020-04-23)
 
 - First release on PyPI.

--- a/py/MANIFEST.in
+++ b/py/MANIFEST.in
@@ -1,5 +1,7 @@
 include CHANGELOG.md
 include README.md
+include requirements.txt
+include requirements_dev.txt
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/py/MANIFEST.in
+++ b/py/MANIFEST.in
@@ -1,0 +1,8 @@
+include CHANGELOG.md
+include README.md
+
+recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/py/README.md
+++ b/py/README.md
@@ -1,0 +1,13 @@
+# pydeck-earthengine-layers
+
+Pydeck wrapper for use with Google Earth Engine
+
+## Install
+
+```bash
+pip install pydeck-earthengine-layers
+```
+
+This also ensures [pydeck](https://pydeck.gl/) is installed. If you haven't
+previously enabled pydeck to be used with Jupyter, follow [its
+instructions](https://pydeck.gl/installation.html) to install.

--- a/py/README.md
+++ b/py/README.md
@@ -15,7 +15,7 @@ instructions](https://pydeck.gl/installation.html) to install.
 ## Using
 
 For an example, see the
-[`examples/Introduction.ipynb`](examples/Introduction.ipynb) Jupyter Notebook.
+[`examples/Introduction.ipynb`](https://raw.githubusercontent.com/UnfoldedInc/earthengine-layers/master/py/examples/Introduction.ipynb) Jupyter Notebook.
 
 ## Release notes
 

--- a/py/README.md
+++ b/py/README.md
@@ -11,3 +11,32 @@ pip install pydeck-earthengine-layers
 This also ensures [pydeck](https://pydeck.gl/) is installed. If you haven't
 previously enabled pydeck to be used with Jupyter, follow [its
 instructions](https://pydeck.gl/installation.html) to install.
+
+## Using
+
+For an example, see the
+[`examples/Introduction.ipynb`](examples/Introduction.ipynb) Jupyter Notebook.
+
+## Release notes
+
+To release, bump the version by running:
+
+```bash
+bumpversion patch
+// or
+bumpversion minor
+```
+
+Then create a dist bundle with:
+
+```bash
+python setup.py sdist
+```
+
+Then upload to PyPI with
+
+```bash
+twine upload dist/pydeck-earthengine-layers-0.1.0.tar.gz
+```
+
+replacing with the current version number.

--- a/py/examples/Introduction.ipynb
+++ b/py/examples/Introduction.ipynb
@@ -1,0 +1,270 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pydeck Earth Engine Introduction\n",
+    "\n",
+    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
+    "```\n",
+    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
+    "source activate pydeck-ee\n",
+    "\n",
+    "# Install the pydeck-earthengine-layers package from pip\n",
+    "pip install pydeck-earthengine-layers\n",
+    "\n",
+    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
+    "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "```\n",
+    "then open Jupyter Notebook with `jupyter notebook`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now in a Python Jupyter Notebook, let's first import required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydeck_earthengine_layers import EarthEngineLayer\n",
+    "import pydeck as pdk\n",
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "### Authenticate with Earth Engine\n",
+    "\n",
+    "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
+    "\n",
+    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "ee.Authenticate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Earth Engine\n",
+    "\n",
+    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Elevation data example\n",
+    "\n",
+    "Now let's make a simple example using Shuttle Radar Topography Mission (SRTM) elevation data. Here we create an `ee.Image` object referencing that dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = ee.Image('CGIAR/SRTM90_V4')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to create the Pydeck layer. The `EarthEngineLayer` makes this simple. Just pass the Earth Engine object to the class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee_layer = EarthEngineLayer(image, vis_params={\"min\": 0, \"max\": 255})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7746b478d8be4c0ba355e39853ea0826",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[ee_layer], \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hillshade Example\n",
+    "\n",
+    "As a slightly more in-depth example, let's use the SRTM dataset to calculate hillshading. This example comes from "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# From https://github.com/giswqs/earthengine-py-notebooks/blob/master/Visualization/hillshade.ipynb\n",
+    "# Add Earth Engine dataset\n",
+    "import math\n",
+    "\n",
+    "def Radians(img):\n",
+    "  return img.toFloat().multiply(math.pi).divide(180)\n",
+    "\n",
+    "def Hillshade(az, ze, slope, aspect):\n",
+    "  \"\"\"Compute hillshade for the given illumination az, el.\"\"\"\n",
+    "  azimuth = Radians(ee.Image(az))\n",
+    "  zenith = Radians(ee.Image(ze))\n",
+    "  # Hillshade = cos(Azimuth - Aspect) * sin(Slope) * sin(Zenith) +\n",
+    "  #     cos(Zenith) * cos(Slope)\n",
+    "  return (azimuth.subtract(aspect).cos()\n",
+    "          .multiply(slope.sin())\n",
+    "          .multiply(zenith.sin())\n",
+    "          .add(\n",
+    "              zenith.cos().multiply(slope.cos())))\n",
+    "\n",
+    "terrain = ee.Algorithms.Terrain(ee.Image('srtm90_v4'))\n",
+    "slope_img = Radians(terrain.select('slope'))\n",
+    "aspect_img = Radians(terrain.select('aspect'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0eaf2af218e4b4bb753623444373790",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ee_object = Hillshade(0, 60, slope_img, aspect_img)\n",
+    "ee_layer = EarthEngineLayer(ee_object)\n",
+    "view_state = pdk.ViewState(latitude=36.0756, longitude=-111.9987, zoom=7, bearing=0, pitch=30)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[ee_layer], \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/py/pydeck_earthengine_layers/__init__.py
+++ b/py/pydeck_earthengine_layers/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Kyle Barron"""
 __email__ = 'kyle@unfolded.ai'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 from .pydeck_earthengine_layers import EarthEngineLayer

--- a/py/pydeck_earthengine_layers/__init__.py
+++ b/py/pydeck_earthengine_layers/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for pydeck-earthengine-layers."""
+
+__author__ = """Kyle Barron"""
+__email__ = 'kyle@unfolded.ai'
+__version__ = '0.1.0'
+
+from .pydeck_earthengine_layers import EarthEngineLayer

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -82,10 +82,12 @@ class EarthEngineLayer(pdk.Layer):
 
         token_dict = r.json()
 
-        # Set expiration time
+        # Set expiration time: expires_in * .9
+        # See reference EE API code here:
+        # https://github.com/google/earthengine-api/blob/5909d9a19a9b829d49b69f38ac4205b4924b21c9/javascript/src/apiclient.js#L1107
         self.access_token = token_dict['access_token']
         self.token_expiration = datetime.now() + timedelta(
-            seconds=token_dict['expires_in'] - 1)
+            seconds=token_dict['expires_in'] * .9)
 
     @property
     def token(self):

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -35,12 +35,16 @@ class EarthEngineLayer(pdk.Layer):
         # Initialize token expiration to the past
         self.access_token = None
         self.token_expiration = datetime.now() - timedelta(seconds=1)
+
+        # Define _token as an attribute, so `token` shows up in `vars(class)`
         self._token = self.token
 
         self.ee_object = ee_object.serialize() if not isinstance(
             ee_object, str) else ee_object
 
-        # This keeps pydeck from
+        # This keeps pydeck from serializing these attributes to JS
+        # Note: this might be global, but other layers shouldn't depend on these
+        # keys
         pdk.bindings.json_tools.IGNORE_KEYS.extend([
             'credentials', 'access_token', 'token_expiration'])
 

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -1,0 +1,94 @@
+"""Main module."""
+
+from datetime import datetime, timedelta
+
+import ee
+import pydeck as pdk
+import requests
+
+EARTHENGINE_LAYER_BUNDLE_URL = 'https://cdn.jsdelivr.net/gh/UnfoldedInc/earthengine-layers@master/modules/earthengine-layers/dist/bundle.js'
+
+
+class EarthEngineLayer(pdk.Layer):
+    """Wrapper class for using the Earth Engine custom layer with Pydeck
+    """
+    def __init__(self, ee_object, credentials=None, **kwargs):
+        """EarthEngineLayer constructor
+
+        Args:
+            - ee_object: Earth Engine object
+            - vis_params: Dict of vis_params to pass to the Earth Engine backend
+            - credentials: Custom credentials. Saved credentials will be loaded
+              if not passed.
+
+        """
+        super(EarthEngineLayer, self).__init__(
+            'EarthEngineLayer', None, **kwargs)
+
+        # Should we assume ee has already been initialized?
+        ee.Initialize()
+
+        self._set_custom_library()
+
+        self.credentials = credentials or ee.data.get_persistent_credentials()
+
+        # Initialize token expiration to the past
+        self.access_token = None
+        self.token_expiration = datetime.now() - timedelta(seconds=1)
+        self._token = self.token
+
+        self.ee_object = ee_object.serialize() if not isinstance(
+            ee_object, str) else ee_object
+
+        # This keeps pydeck from
+        pdk.bindings.json_tools.IGNORE_KEYS.extend([
+            'credentials', 'access_token', 'token_expiration'])
+
+    def _set_custom_library(
+            self,
+            library_name='EarthEngineLayerLibrary',
+            url=EARTHENGINE_LAYER_BUNDLE_URL):
+        """Add EarthEngineLayer JS bundle to pydeck's custom libraries
+        """
+        custom_library = {'libraryName': library_name, 'resourceUri': url}
+
+        if pdk.settings.custom_libraries is None:
+            pdk.settings.custom_libraries = [custom_library]
+            return
+
+        exists = any([
+            x.get('libraryName') == library_name
+            for x in pdk.settings.custom_libraries])
+
+        if not exists:
+            pdk.settings.custom_libraries.append(custom_library)
+
+    def _refresh_token(self):
+        """Retrieve OAuth2 access token using persistent credentials
+        """
+        data = {
+            'client_id': self.credentials.client_id,
+            'client_secret': self.credentials.client_secret,
+            'refresh_token': self.credentials.refresh_token,
+            'grant_type': 'refresh_token'}
+        r = requests.post(self.credentials.token_uri, data=data)
+
+        if r.status_code != 200:
+            raise ValueError('Unable to fetch access token')
+
+        token_dict = r.json()
+
+        # Set expiration time
+        self.access_token = token_dict['access_token']
+        self.token_expiration = datetime.now() + timedelta(
+            seconds=token_dict['expires_in'] - 1)
+
+    @property
+    def token(self):
+        """Load existing access_token, or fetch a new one if expired
+        """
+        if datetime.now() < self.token_expiration:
+            return self.access_token
+
+        self._refresh_token()
+        return self.access_token

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,0 +1,3 @@
+earthengine-api>=0.1.215
+pydeck>=0.3.0
+requests

--- a/py/requirements_dev.txt
+++ b/py/requirements_dev.txt
@@ -1,0 +1,12 @@
+pip==19.2.3
+bump2version==0.5.11
+wheel==0.33.6
+watchdog==0.9.0
+flake8==3.7.8
+tox==3.14.0
+coverage==4.5.4
+Sphinx==1.8.5
+twine==1.14.0
+
+pytest==4.6.5
+pytest-runner==5.1

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 
@@ -18,7 +18,6 @@ universal = 1
 exclude = docs
 
 [aliases]
-# Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,7 +1,5 @@
 [bumpversion]
 current_version = 0.1.1
-commit = True
-tag = True
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,0 +1,26 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bumpversion:file:pydeck_earthengine_layers/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+
+[bdist_wheel]
+universal = 1
+
+[flake8]
+exclude = docs
+
+[aliases]
+# Define setup.py command aliases here
+test = pytest
+
+[tool:pytest]
+collect_ignore = ['setup.py']
+

--- a/py/setup.py
+++ b/py/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/UnfoldedInc/earthengine-layers/blob/master/py',
-    version='0.1.1',
+    version='0.1.0',
     zip_safe=False,
 )

--- a/py/setup.py
+++ b/py/setup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+"""The setup script."""
+
+from setuptools import find_packages, setup
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+with open('CHANGELOG.md') as history_file:
+    history = history_file.read()
+
+with open('requirements.txt') as requirements_file:
+    requirements = [l.strip() for l in requirements_file.readlines()]
+
+with open('requirements_dev.txt') as test_requirements_file:
+    test_requirements = [l.strip() for l in test_requirements_file.readlines()]
+
+setup_requirements = ['setuptools >= 38.6.0', 'twine >= 1.11.0']
+
+setup(
+    author="Kyle Barron",
+    author_email='kyle@unfolded.ai',
+    python_requires='>=3.5',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    description="Pydeck wrapper for use with Google Earth Engine",
+    install_requires=requirements,
+    license="MIT license",
+    long_description=readme + '\n\n' + history,
+    long_description_content_type='text/markdown',
+    include_package_data=True,
+    keywords='pydeck_earthengine_layers',
+    name='pydeck-earthengine-layers',
+    packages=find_packages(include=['pydeck_earthengine_layers', 'pydeck_earthengine_layers.*']),
+    setup_requires=setup_requirements,
+    test_suite='tests',
+    tests_require=test_requirements,
+    url='https://github.com/UnfoldedInc/earthengine-layers/blob/master/py',
+    version='0.1.1',
+    zip_safe=False,
+)

--- a/py/setup.py
+++ b/py/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/UnfoldedInc/earthengine-layers/blob/master/py',
-    version='0.1.0',
+    version='0.1.1',
     zip_safe=False,
 )


### PR DESCRIPTION
Simple wrapper class for using Earth Engine in Pydeck

**Handles**

- Loading credentials
- Refreshing access token as needed when it expires
- Serializing EE objects to strings
- Add EE JS bundle to pydeck's custom libraries setting

**Example**

A simpler version of the existing notebook is included ([rendered](https://nbviewer.jupyter.org/github/kylebarron/earthengine-layers/blob/python-wrapper/py/examples/Introduction.ipynb)). Creating the layer simplifies to:

```py
from pydeck_earthengine_layers import EarthEngineLayer
import pydeck as pdk
import ee

ee.Initialize()

image = ee.Image('CGIAR/SRTM90_V4')
ee_layer = EarthEngineLayer(image, vis_params={"min": 0, "max": 255})
```

**Questions**

- Regarding the API, currently `ee_object` is set as the first positional parameter, and optional `credentials` argument is the second. But any other arguments are collected into `kwargs`. Therefore only `ee_object` and `credentials` may be positional parameters. If someone passes `EarthEngineLayer(ee_object, vis_params)`, it'll crash, and needs to instead be `EarthEngineLayer(ee_object, vis_params=vis_params)`. It may be wise to include a check that if `credentials` is passed, it's an instance of the Google OAuth credentials object, as a hint to the user.

	A user may be used to [`Map.addLayer`](https://developers.google.com/earth-engine/api_docs#mapaddlayer), which has five positional arguments:

	```js
	Map.addLayer(eeObject, visParams, name, shown, opacity)
	```

	So this check might be helpful to a new user.


A beta 0.1.0 version is [published to PyPI](https://pypi.org/project/pydeck-earthengine-layers/0.1.0/).

cc @ajduberstein