### PR TITLE
pydeck: Option to set custom ee layer bundle url

### DIFF
--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -23,9 +23,10 @@ class EarthEngineLayer(pdk.Layer):
         Args:
             - ee_object: Earth Engine object
             - vis_params: Dict of vis_params to pass to the Earth Engine backend
-            - credentials: Custom credentials. Saved credentials will be loaded
-              if not passed.
-
+            - credentials: Google OAuth2 credentials object. Saved credentials
+              will be loaded if not passed.
+            - library_url: URL from which to load EarthEngineLayer JavaScript
+              bundle
         """
         super(EarthEngineLayer, self).__init__(
             'EarthEngineLayer', None, **kwargs)

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -12,7 +12,12 @@ EARTHENGINE_LAYER_BUNDLE_URL = 'https://cdn.jsdelivr.net/gh/UnfoldedInc/eartheng
 class EarthEngineLayer(pdk.Layer):
     """Wrapper class for using the Earth Engine custom layer with Pydeck
     """
-    def __init__(self, ee_object, credentials=None, **kwargs):
+    def __init__(
+            self,
+            ee_object,
+            credentials=None,
+            library_url=EARTHENGINE_LAYER_BUNDLE_URL,
+            **kwargs):
         """EarthEngineLayer constructor
 
         Args:
@@ -28,7 +33,7 @@ class EarthEngineLayer(pdk.Layer):
         # Should we assume ee has already been initialized?
         ee.Initialize()
 
-        self._set_custom_library()
+        self._set_custom_library(url=library_url)
 
         self.credentials = credentials or ee.data.get_persistent_credentials()
 


### PR DESCRIPTION
The url to retrieve the custom `earthengine-layer` layer bundle is currently hardcoded to the jsdeliver cdn pointing to this master branch. This PR adds an optional argument to the class constructor to point to a custom url. This is helpful for debugging/testing changes, so that I can build a rollup bundle locally, serve it on `localhost`, and point the class to load from `localhost`.