### PR TITLE
Fix forwarding props to TileLayer

### DIFF
--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -72,10 +72,7 @@ export default class App extends React.Component {
       new EarthEngineLayer({
         eeObject: this.state.eeImage,
         visParams: {min: 0, max: 255},
-        opacity: 0.5,
-        // Prevent overlapping tiles from multiple zoom levels
-        // https://deck.gl/#/documentation/deckgl-api-reference/layers/tile-layer?section=refinementstrategy-enum-optional-
-        refinementStrategy: 'no-overlap'
+        opacity: 0.5
       })
     ];
 

--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -75,7 +75,7 @@ export default class App extends React.Component {
         opacity: 0.5,
         // Do not display any tile that is not selected
         // https://deck.gl/#/documentation/deckgl-api-reference/layers/tile-layer?section=refinementstrategy-enum-optional-
-        refinementStrategy: 'never'
+        refinementStrategy: 'no-overlap'
       })
     ];
 

--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -73,7 +73,7 @@ export default class App extends React.Component {
         eeObject: this.state.eeImage,
         visParams: {min: 0, max: 255},
         opacity: 0.5,
-        // Do not display any tile that is not selected
+        // Prevent overlapping tiles from multiple zoom levels
         // https://deck.gl/#/documentation/deckgl-api-reference/layers/tile-layer?section=refinementstrategy-enum-optional-
         refinementStrategy: 'no-overlap'
       })

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -105,7 +105,8 @@ export default class EarthEngineLayer extends CompositeLayer {
       getTileUrl &&
       new TileLayer(
         this.getSubLayerProps({
-          id: 'tiles'
+          id: 'tiles',
+          ...this.props,
         }),
         {
           id: this._getLayerId(getTileUrl),

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -101,24 +101,33 @@ export default class EarthEngineLayer extends CompositeLayer {
 
   renderLayers() {
     const {getTileUrl} = this.state;
+    const {
+      refinementStrategy,
+      onViewportLoad,
+      onTileLoad,
+      onTileError,
+      maxZoom,
+      minZoom,
+      maxCacheSize,
+      maxCacheByteSize
+    } = this.props;
 
     return (
       getTileUrl &&
       new TileLayer(
         this.getSubLayerProps({
-          id: 'tiles',
-          refinementStrategy: this.props.refinementStrategy,
-          onViewportLoad: this.props.onViewportLoad,
-          onTileLoad: this.props.onTileLoad,
-          onTileError: this.props.onTileError,
-          maxZoom: this.props.maxZoom,
-          minZoom: this.props.minZoom,
-          maxCacheSize: this.props.maxCacheSize,
-          maxCacheByteSize: this.props.maxCacheByteSize,
-          zRange: this.props.zRange
+          id: this._getLayerId(getTileUrl)
         }),
         {
-          id: this._getLayerId(getTileUrl),
+          refinementStrategy,
+          onViewportLoad,
+          onTileLoad,
+          onTileError,
+          maxZoom,
+          minZoom,
+          maxCacheSize,
+          maxCacheByteSize,
+
           async getTileData({x, y, z}) {
             const imageUrl = getTileUrl(x, y, z);
             const image = await load(imageUrl, ImageLoader);

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -18,7 +18,8 @@ const defaultProps = {
   data: {type: 'object', value: null},
   token: {type: 'string', value: null},
   eeObject: {type: 'object', value: null},
-  visParams: {type: 'object', value: null}
+  visParams: {type: 'object', value: null},
+  refinementStrategy: 'no-overlap'
 };
 
 export default class EarthEngineLayer extends CompositeLayer {
@@ -106,7 +107,15 @@ export default class EarthEngineLayer extends CompositeLayer {
       new TileLayer(
         this.getSubLayerProps({
           id: 'tiles',
-          ...this.props,
+          refinementStrategy: this.props.refinementStrategy,
+          onViewportLoad: this.props.onViewportLoad,
+          onTileLoad: this.props.onTileLoad,
+          onTileError: this.props.onTileError,
+          maxZoom: this.props.maxZoom,
+          minZoom: this.props.minZoom,
+          maxCacheSize: this.props.maxCacheSize,
+          maxCacheByteSize: this.props.maxCacheByteSize,
+          zRange: this.props.zRange
         }),
         {
           id: this._getLayerId(getTileUrl),


### PR DESCRIPTION
Forwards all props passed to `EarthEngineLayer` down to `TileLayer`. Closes #36 

- Do I need to use `Object.assign` instead of spreading `...this.props`?
- There's still a little bit of "flicker" with alternative `refinementStrategy` methods. For now I have the `ee-demo` example set to `refinementStrategy: 'no-overlap'`.

	`refinementStrategy: 'no-overlap'`: Some empty tiles when loading at a new zoom
	![Screen Recording 2020-05-04 at 3 52 00 PM](https://user-images.githubusercontent.com/15164633/81017915-9e0d7080-8e20-11ea-9018-d77e67067d9e.gif)

	`refinementStrategy: 'never'`: At every zoom threshold, the entire map is white while tiles load.
	![Screen Recording 2020-05-04 at 3 56 04 PM](https://user-images.githubusercontent.com/15164633/81017913-9d74da00-8e20-11ea-9c83-d0bcc59268d3.gif)