### PR TITLE
Fix `gatsby-config.js`

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -14,10 +14,7 @@ module.exports = {
         ROOT_FOLDER: `${__dirname}/../`,
 
         DOCS: DOC_TABLE_OF_CONTENTS,
-        DOC_FOLDERS: [
-          `${__dirname}/../docs/`,
-          `${__dirname}/../modules/`
-        ],
+        DOC_FOLDERS: [`${__dirname}/../docs/`, `${__dirname}/../modules/`],
         SOURCE: [`${__dirname}/static`, `${__dirname}/src`],
 
         PROJECT_TYPE: 'github',
@@ -54,7 +51,7 @@ module.exports = {
 
         LINK_TO_GET_STARTED: '/docs/developer-guide/get-started',
 
-        ADDITIONAL_LINKS: [{name: 'Blog', href: 'http://medium.com/vis-gl'}],
+        ADDITIONAL_LINKS: [{name: 'Blog', href: 'http://medium.com/vis-gl', index: 1}],
 
         INDEX_PAGE_URL: resolve(__dirname, './templates/index.jsx'),
 
@@ -65,7 +62,9 @@ module.exports = {
             componentUrl: resolve(__dirname, '../examples/ee-demo/app.js'),
             path: 'examples/earthengine-layer'
           }
-        ]
+        ],
+
+        STYLESHEETS: ['https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.0/mapbox-gl.css']
       }
     },
     {resolve: 'gatsby-plugin-no-sourcemaps'},

--- a/website/package.json
+++ b/website/package.json
@@ -35,9 +35,9 @@
     "@luma.gl/webgl": "^8.1.0",
     "@math.gl/culling": "^3.1.3",
     "@math.gl/geospatial": "^3.1.3",
-    "@probe.gl/stats-widget": "^3.3.0-alpha.8",
     "@probe.gl/bench": "^3.3.0-alpha.8",
     "@probe.gl/react-bench": "^3.3.0-alpha.8",
+    "@probe.gl/stats-widget": "^3.3.0-alpha.8",
     "babel-plugin-version-inline": "^1.0.0",
     "gatsby-plugin-env-variables": "^1.0.1",
     "marked": "^0.7.0",
@@ -48,7 +48,7 @@
     "styled-components": "^4.4.1"
   },
   "devDependencies": {
-    "gatsby": "~2.18.25",
+    "gatsby": "^2.21.16",
     "gatsby-plugin-no-sourcemaps": "^2.1.2",
     "gatsby-theme-ocular": "^1.2.0-beta.8",
     "gh-pages": "^2.2.0"


### PR DESCRIPTION
Adds the `index` field on `ADDITIONAL_LINKS`, adds the required `STYLESHEETS` field. If we aren't using `Mapbox GL JS` at all in any examples, we could remove the entry, but `STYLESHEETS` needs to be an empty array at least.

With these changes the website builds correctly locally.