### PR TITLE
Working example on website

### DIFF
--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -77,14 +77,16 @@ export default class App extends React.Component {
     ];
 
     return (
-      <DeckGL
-        controller
-        onViewStateChange={this._onViewStateChange}
-        viewState={this.state.viewState}
-        layers={layers}
-      >
-        <GoogleLoginPane loginProvider={this.loginProvider} />
-      </DeckGL>
+      <div style={{position: 'relative', height: '100%'}}>
+        <DeckGL
+          controller
+          onViewStateChange={this._onViewStateChange}
+          viewState={this.state.viewState}
+          layers={layers}
+        >
+          <GoogleLoginPane loginProvider={this.loginProvider} />
+        </DeckGL>
+      </div>
     );
   }
 }

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -71,7 +71,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-env-variables',
       options: {
-        whitelist: ['MapboxAccessToken'] // TODO replace with Google Maps integration
+        whitelist: ['MapboxAccessToken', 'EE_CLIENT_ID'] // TODO replace with Google Maps integration
       }
     }
   ]

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "build": "yarn clean-examples && yarn clean && gatsby build",
     "clean": "rm -rf ./.cache ./public",
     "clean-examples": "find ../examples -name node_modules -exec rm -r {} \\; || true",
-    "develop": "yarn clean-examples && gatsby develop",
+    "develop": "yarn clean-examples && gatsby develop --port 8080",
     "serve": "gatsby serve",
     "deploy": "NODE_DEBUG=gh-pages gh-pages -d public"
   },


### PR DESCRIPTION
- Add `EE_CLIENT_ID` to `gatsby-plugin-env-variables`
- Make Gatsby load on port 8080. It looks like specific ports have to be whitelisted for use with a given Client ID, and the default Gatsby port of 8000 isn't whitelisted.

Then to start website:
```bash
cd website
yarn
export EE_CLIENT_ID=...
yarn run start
```

Closes #42 , closes #41