### PR TITLE
Fix link to pydeck-integration

### DIFF
--- a/docs/developer-guide/get-started.md
+++ b/docs/developer-guide/get-started.md
@@ -12,7 +12,7 @@ $ yarn add @deck.gl/core @deck.gl/layers @deck.gl/geo-layers
 
 The `EarthEngineLayer` can be used as a plugin layer to [`pydeck`](https://pydeck.gl).
 
-For more information see [pydeck integration](docs/developer-guide/pydeck-integration.md).
+For more information see [pydeck integration](/docs/developer-guide/pydeck-integration.md).
 
 ## Using in JavaScript
 


### PR DESCRIPTION
When using an _absolute_ link to the markdown file, the link works on both Github docs and in Gatsby/ocular. Tested on my branch on Github and in Gatsby.

Closes #6.