### PR TITLE
Remove custom getMapAsync

### DIFF
--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -5,7 +5,7 @@ import EEApi from './ee-api'; // Promisify ee apis
 import ee from '@google/earthengine';
 import {load} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
-import {deepEqual, getMapAsync} from './utils';
+import {deepEqual, promisifyEEObject} from './utils';
 
 const eeApi = new EEApi();
 // Global access token, to allow single EE API initialization if using multiple
@@ -80,7 +80,7 @@ export default class EarthEngineLayer extends CompositeLayer {
     }
 
     // Evaluate map
-    const map = await getMapAsync(eeObject, props.visParams);
+    const map = await promisifyEEObject(eeObject, 'getMap', props.visParams);
 
     // Get a tile url generation function
     const getTileUrl = map.formatTileUrl.bind(map);

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -5,7 +5,7 @@ import EEApi from './ee-api'; // Promisify ee apis
 import ee from '@google/earthengine';
 import {load} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
-import {deepEqual} from './utils';
+import {deepEqual, getMapAsync} from './utils';
 
 const eeApi = new EEApi();
 // Global access token, to allow single EE API initialization if using multiple
@@ -80,15 +80,7 @@ export default class EarthEngineLayer extends CompositeLayer {
     }
 
     // Evaluate map
-    const map = await new Promise((resolve, reject) =>
-      eeObject.getMap(props.visParams, (value, error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve(value);
-      })
-    );
+    const map = await getMapAsync(eeObject, props.visParams);
 
     // Get a tile url generation function
     const getTileUrl = map.formatTileUrl.bind(map);

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -80,7 +80,15 @@ export default class EarthEngineLayer extends CompositeLayer {
     }
 
     // Evaluate map
-    const map = await eeObject.getMapAsync(props.visParams);
+    const map = await new Promise((resolve, reject) =>
+      eeObject.getMap(props.visParams, (value, error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(value);
+      })
+    );
 
     // Get a tile url generation function
     const getTileUrl = map.formatTileUrl.bind(map);

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -5,7 +5,7 @@ import EEApi from './ee-api'; // Promisify ee apis
 import ee from '@google/earthengine';
 import {load} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
-import {deepEqual, promisifyEEObject} from './utils';
+import {deepEqual, promisifyEEMethod} from './utils';
 
 const eeApi = new EEApi();
 // Global access token, to allow single EE API initialization if using multiple
@@ -80,7 +80,7 @@ export default class EarthEngineLayer extends CompositeLayer {
     }
 
     // Evaluate map
-    const map = await promisifyEEObject(eeObject, 'getMap', props.visParams);
+    const map = await promisifyEEMethod(eeObject, 'getMap', props.visParams);
 
     // Get a tile url generation function
     const getTileUrl = map.formatTileUrl.bind(map);

--- a/modules/earthengine-layers/src/ee-api.js
+++ b/modules/earthengine-layers/src/ee-api.js
@@ -1,7 +1,5 @@
 import ee from '@google/earthengine';
 
-promisifyEEAPIs();
-
 export default class EEApi {
   constructor() {
     this.ee = ee;
@@ -51,22 +49,4 @@ export default class EEApi {
       ee.initialize(baseurl, tileurl, value => resolve(value), error => reject(error));
     });
   }
-}
-
-function promisifyEEAPIs() {
-  async function getMapAsync(visParams) {
-    return await new Promise((resolve, reject) =>
-      // eslint-disable-next-line no-invalid-this
-      this.getMap(visParams, (value, error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve(value);
-      })
-    );
-  }
-
-  ee.Image.prototype.getMapAsync = getMapAsync;
-  ee.ImageCollection.prototype.getMapAsync = getMapAsync;
 }

--- a/modules/earthengine-layers/src/utils.js
+++ b/modules/earthengine-layers/src/utils.js
@@ -21,7 +21,7 @@ export function deepEqual(a, b) {
 }
 
 // Promisify eeObject methods
-export function promisifyEEObject(eeObject, method, ...args) {
+export function promisifyEEMethod(eeObject, method, ...args) {
   return new Promise((resolve, reject) =>
     eeObject[method](...args, (value, error) => {
       if (error) {

--- a/modules/earthengine-layers/src/utils.js
+++ b/modules/earthengine-layers/src/utils.js
@@ -19,3 +19,16 @@ export function deepEqual(a, b) {
   }
   return true;
 }
+
+// Promisify eeObject.getMap
+export function getMapAsync(eeObject, visParams) {
+  return new Promise((resolve, reject) =>
+    eeObject.getMap(visParams, (value, error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(value);
+    })
+  );
+}

--- a/modules/earthengine-layers/src/utils.js
+++ b/modules/earthengine-layers/src/utils.js
@@ -20,10 +20,10 @@ export function deepEqual(a, b) {
   return true;
 }
 
-// Promisify eeObject.getMap
-export function getMapAsync(eeObject, visParams) {
+// Promisify eeObject methods
+export function promisifyEEObject(eeObject, method, ...args) {
   return new Promise((resolve, reject) =>
-    eeObject.getMap(visParams, (value, error) => {
+    eeObject[method](...args, (value, error) => {
       if (error) {
         reject(error);
         return;


### PR DESCRIPTION
Removes custom `promisifyEEAPIs` and instead creates the `Promise` in place. Closes #46.