### PR TITLE
Set vis_params as second positional argument

### DIFF
--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -15,6 +15,7 @@ class EarthEngineLayer(pdk.Layer):
     def __init__(
             self,
             ee_object,
+            vis_params=None,
             credentials=None,
             library_url=EARTHENGINE_LAYER_BUNDLE_URL,
             **kwargs):
@@ -29,7 +30,7 @@ class EarthEngineLayer(pdk.Layer):
               bundle
         """
         super(EarthEngineLayer, self).__init__(
-            'EarthEngineLayer', None, **kwargs)
+            'EarthEngineLayer', None, vis_params=vis_params, **kwargs)
 
         # Should we assume ee has already been initialized?
         ee.Initialize()


### PR DESCRIPTION
Closes #55 

Means a user can do:
```py
ee_object = ee.ImageCollection('NOAA/GFS0P25').filterDate('2018-12-22', '2018-12-23').limit(24).select('temperature_2m_above_ground')
vis_params = {
      "min": -40.0,
      "max": 35.0,
      "palette": ['blue', 'purple', 'cyan', 'green', 'yellow', 'red']
}
ee_layer = EarthEngineLayer(
    ee_object,
    vis_params,
    animate=True
)
```
whereas currently it's required to pass `vis_params` as a keyword argument, i.e.
```py
ee_layer = EarthEngineLayer(
    ee_object,
    vis_params=vis_params,
    animate=True
)
```

All props other than `ee_object` and `vis_params` are required to be keyword arguments, and I think they should stay that way. I think that users would be used to the EE API, where `eeObject` and `visParams` are the first two positional parameters. `visParams` is still _allowed_ to be a keyword parameter, but not required with this change.