### PR TITLE
Support multiple JS examples

### DIFF
--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -7,7 +7,6 @@ import {GoogleLoginProvider} from '@unfolded.gl/earthengine-layers';
 
 import {GoogleLoginPane} from '../shared/react-components';
 // import {GoogleEarthEngineIcon} from '../shared/react-components';
-import {ImageExampleLayers, ImageCollectionExampleLayers} from './examples';
 
 // Add a EE-enabled Google Client id here (or inject it with e.g. a webpack environment plugin)
 // eslint-disable-next-line
@@ -55,23 +54,10 @@ export default class App extends React.Component {
   }
 
   render() {
-    const {exampleName = 'imagecollection'} = this.props;
+    const {layersFunction} = this.props;
     const {loggedIn} = this.state;
 
-    let layers;
-    if (loggedIn) {
-      switch (exampleName.toLowerCase()) {
-        case 'image':
-          layers = ImageExampleLayers();
-          break;
-        case 'imagecollection':
-          layers = ImageCollectionExampleLayers();
-          break;
-        default:
-          break;
-      }
-    }
-
+    const layers = loggedIn && layersFunction();
     return (
       <div style={{position: 'relative', height: '100%'}}>
         <DeckGL controller initialViewState={defaultViewState} layers={layers}>

--- a/examples/ee-demo/app.js
+++ b/examples/ee-demo/app.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import {render} from 'react-dom';
 
-import ee from '@google/earthengine';
-
 import DeckGL from '@deck.gl/react';
-import {EEApi, EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
+import {EEApi} from '@unfolded.gl/earthengine-layers';
 import {GoogleLoginProvider} from '@unfolded.gl/earthengine-layers';
 
 import {GoogleLoginPane} from '../shared/react-components';
 // import {GoogleEarthEngineIcon} from '../shared/react-components';
+import {ImageExampleLayers, ImageCollectionExampleLayers} from './examples';
 
 // Add a EE-enabled Google Client id here (or inject it with e.g. a webpack environment plugin)
 // eslint-disable-next-line
@@ -29,7 +28,6 @@ export default class App extends React.Component {
     super(props);
 
     this._onLoginSuccess = this._onLoginSuccess.bind(this);
-    this._onViewStateChange = this._onViewStateChange.bind(this);
 
     this.loginProvider = new GoogleLoginProvider({
       clientId: EE_CLIENT_ID,
@@ -39,64 +37,44 @@ export default class App extends React.Component {
 
     this.eeApi = new EEApi();
 
-    this.state = {
-      viewState: defaultViewState,
-      eeObject: null,
-      visParams: null
-    };
+    this.state = {loggedIn: false};
   }
 
   async _onLoginSuccess(user, loginProvider) {
     // TODO - called twice, this should not be needed
-    if (this.loggedIn) {
+    const {loggedIn} = this.state;
+    if (loggedIn) {
       return;
     }
-    this.loggedIn = true;
 
     this.forceUpdate();
     // Client id to your EE application
     await this.eeApi.initialize({clientId: EE_CLIENT_ID});
-
-    // Old elevation example
-    // Eventually we'll have multiple examples
-    // const eeObject = ee.Image('CGIAR/SRTM90_V4').serialize();
-    // this.setState({eeObject});
-    const eeObject = ee
-      .ImageCollection('NOAA/GFS0P25')
-      .filterDate('2018-12-22', '2018-12-23')
-      .limit(48)
-      .select('temperature_2m_above_ground');
-    const visParams = {
-      min: -40.0,
-      max: 35.0,
-      palette: ['blue', 'purple', 'cyan', 'green', 'yellow', 'red']
-    };
-    this.setState({eeObject, visParams});
-  }
-
-  _onViewStateChange({viewState}) {
-    this.setState({viewState});
+    // Must be after initialization
+    this.setState({loggedIn: true});
   }
 
   render() {
-    const {eeObject, visParams, viewState} = this.state;
+    const {exampleName = 'imagecollection'} = this.props;
+    const {loggedIn} = this.state;
 
-    const layers = eeObject && [
-      new EarthEngineLayer({
-        eeObject,
-        visParams,
-        opacity: 0.5
-      })
-    ];
+    let layers;
+    if (loggedIn) {
+      switch (exampleName.toLowerCase()) {
+        case 'image':
+          layers = ImageExampleLayers();
+          break;
+        case 'imagecollection':
+          layers = ImageCollectionExampleLayers();
+          break;
+        default:
+          break;
+      }
+    }
 
     return (
       <div style={{position: 'relative', height: '100%'}}>
-        <DeckGL
-          controller
-          onViewStateChange={this._onViewStateChange}
-          viewState={viewState}
-          layers={layers}
-        >
+        <DeckGL controller initialViewState={defaultViewState} layers={layers}>
           <GoogleLoginPane loginProvider={this.loginProvider} />
         </DeckGL>
       </div>

--- a/examples/ee-demo/examples.js
+++ b/examples/ee-demo/examples.js
@@ -1,0 +1,27 @@
+import ee from '@google/earthengine';
+import {EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
+
+export function ImageExampleLayers() {
+  const eeObject = ee.Image('CGIAR/SRTM90_V4');
+  const visParams = {
+    min: 0,
+    max: 4000,
+    palette: ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5']
+  };
+
+  return [new EarthEngineLayer({eeObject, visParams, opacity: 0.5})];
+}
+
+export function ImageCollectionExampleLayers() {
+  const eeObject = ee
+    .ImageCollection('NOAA/GFS0P25')
+    .filterDate('2018-12-22', '2018-12-23')
+    .limit(48)
+    .select('temperature_2m_above_ground');
+  const visParams = {
+    min: -40.0,
+    max: 35.0,
+    palette: ['blue', 'purple', 'cyan', 'green', 'yellow', 'red']
+  };
+  return [new EarthEngineLayer({eeObject, visParams, animate: true})];
+}

--- a/examples/ee-demo/image-collection-animation.js
+++ b/examples/ee-demo/image-collection-animation.js
@@ -5,7 +5,7 @@ import ee from '@google/earthengine';
 import {EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
 import App from './app';
 
-function ImageCollectionExampleLayers() {
+function renderImageCollectionExampleLayers() {
   const eeObject = ee
     .ImageCollection('NOAA/GFS0P25')
     .filterDate('2018-12-22', '2018-12-23')
@@ -20,7 +20,7 @@ function ImageCollectionExampleLayers() {
 }
 
 export default function ImageCollectionExample() {
-  return <App layersFunction={ImageCollectionExampleLayers} />;
+  return <App layersFunction={renderImageCollectionExampleLayers} />;
 }
 
 export function renderToDOM(container) {

--- a/examples/ee-demo/image-collection-animation.js
+++ b/examples/ee-demo/image-collection-animation.js
@@ -1,22 +1,15 @@
+import React from 'react';
+import {render} from 'react-dom';
+
 import ee from '@google/earthengine';
 import {EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
+import App from './app';
 
-export function ImageExampleLayers() {
-  const eeObject = ee.Image('CGIAR/SRTM90_V4');
-  const visParams = {
-    min: 0,
-    max: 4000,
-    palette: ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5']
-  };
-
-  return [new EarthEngineLayer({eeObject, visParams, opacity: 0.5})];
-}
-
-export function ImageCollectionExampleLayers() {
+function ImageCollectionExampleLayers() {
   const eeObject = ee
     .ImageCollection('NOAA/GFS0P25')
     .filterDate('2018-12-22', '2018-12-23')
-    .limit(48)
+    .limit(24)
     .select('temperature_2m_above_ground');
   const visParams = {
     min: -40.0,
@@ -24,4 +17,12 @@ export function ImageCollectionExampleLayers() {
     palette: ['blue', 'purple', 'cyan', 'green', 'yellow', 'red']
   };
   return [new EarthEngineLayer({eeObject, visParams, animate: true})];
+}
+
+export default function ImageCollectionExample() {
+  return <App layersFunction={ImageCollectionExampleLayers} />;
+}
+
+export function renderToDOM(container) {
+  return render(<ImageCollectionExample />, container);
 }

--- a/examples/ee-demo/image.js
+++ b/examples/ee-demo/image.js
@@ -5,7 +5,7 @@ import ee from '@google/earthengine';
 import {EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
 import App from './app';
 
-function ImageExampleLayers() {
+function renderImageExampleLayers() {
   const eeObject = ee.Image('CGIAR/SRTM90_V4');
   const visParams = {
     min: 0,
@@ -17,7 +17,7 @@ function ImageExampleLayers() {
 }
 
 export default function ImageExample() {
-  return <App layersFunction={ImageExampleLayers} />;
+  return <App layersFunction={renderImageExampleLayers} />;
 }
 
 export function renderToDOM(container) {

--- a/examples/ee-demo/image.js
+++ b/examples/ee-demo/image.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {render} from 'react-dom';
+
+import ee from '@google/earthengine';
+import {EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
+import App from './app';
+
+function ImageExampleLayers() {
+  const eeObject = ee.Image('CGIAR/SRTM90_V4');
+  const visParams = {
+    min: 0,
+    max: 4000,
+    palette: ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5']
+  };
+
+  return [new EarthEngineLayer({eeObject, visParams, opacity: 0.5})];
+}
+
+export default function ImageExample() {
+  return <App layersFunction={ImageExampleLayers} />;
+}
+
+export function renderToDOM(container) {
+  return render(<ImageExample />, container);
+}

--- a/examples/ee-demo/index.html
+++ b/examples/ee-demo/index.html
@@ -21,7 +21,7 @@
   </head>
   <body/>
     <div id="app"></div>
-    <script src='./app.js'></script>
+    <script src='./image.js'></script>
   </body>
   <script type="text/javascript">
     App.renderToDOM(document.getElementById('app'));

--- a/examples/ee-demo/webpack.config.js
+++ b/examples/ee-demo/webpack.config.js
@@ -11,7 +11,7 @@ const CONFIG = {
   mode: 'development',
 
   entry: {
-    app: './app.js'
+    app: './image.js'
   },
 
   output: {

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -57,10 +57,16 @@ module.exports = {
 
         EXAMPLES: [
           {
-            title: 'EarthEngineLayer',
+            title: 'Image',
             image: 'images/example-eelayer.png',
-            componentUrl: resolve(__dirname, '../examples/ee-demo/app.js'),
-            path: 'examples/earthengine-layer'
+            componentUrl: resolve(__dirname, '../examples/ee-demo/image.js'),
+            path: 'examples/image'
+          },
+          {
+            title: 'ImageCollection Animation',
+            image: 'images/example-eelayer.png',
+            componentUrl: resolve(__dirname, '../examples/ee-demo/image-collection-animation.js'),
+            path: 'examples/image-collection-animation'
           }
         ],
 


### PR DESCRIPTION
Refactors `app.js` to load examples from an external function, and switch between them based on props. Is this along the lines you were thinking of `ibgreen`? Is this clear enough for users?