### PR TITLE
Add Infobox to example. Fix login

### DIFF
--- a/examples/image/app.js
+++ b/examples/image/app.js
@@ -6,7 +6,7 @@ import {EarthEngineLayer} from '@unfolded.gl/earthengine-layers';
 
 import ee from '@google/earthengine';
 
-import {GoogleLoginProvider, GoogleLoginPane} from '../shared';
+import {GoogleLoginProvider, GoogleLoginPane, InfoBox} from '../shared';
 
 // Add a EE-enabled Google Client id here (or inject it with e.g. a webpack environment plugin)
 const EE_CLIENT_ID = process.env.EE_CLIENT_ID; // eslint-disable-line
@@ -23,9 +23,7 @@ export default class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {eeObject: null};
-  }
 
-  componentDidMount() {
     this.loginProvider = new GoogleLoginProvider({
       scopes: ['https://www.googleapis.com/auth/earthengine'],
       clientId: EE_CLIENT_ID,
@@ -53,6 +51,9 @@ export default class App extends React.Component {
       <div style={{position: 'relative', height: '100%'}}>
         <DeckGL controller initialViewState={INITIAL_VIEW_STATE} layers={layers}>
           <GoogleLoginPane loginProvider={this.loginProvider} />
+          <InfoBox title="Image">
+            Displaying the <code>CGIAR/SRTM90_V4</code> dataset using an ee.ImageObject.
+          </InfoBox>
         </DeckGL>
       </div>
     );

--- a/examples/image/index.html
+++ b/examples/image/index.html
@@ -19,7 +19,7 @@
       }
     </style>
   </head>
-  <body/>
+  <body>
     <div id="app"></div>
     <script src='./app.js'></script>
   </body>

--- a/examples/shared/index.js
+++ b/examples/shared/index.js
@@ -6,3 +6,4 @@ export {default as GoogleEarthEngineIcon} from './react-components/earthengine-i
 
 // React Components
 export {default as GoogleLoginPane} from './react-components/google-login-pane';
+export {default as InfoBox} from './react-components/info-box';

--- a/examples/shared/react-components/info-box.js
+++ b/examples/shared/react-components/info-box.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// import EarthEngineIcon from './earthengine-icon';
+
+const StyledPanel = styled.div`
+  position: absolute;
+  top: 40px;
+  right: 40px;
+  width: 250px;
+  background: lightgrey;
+  z-index: 1000;
+  padding: 24px;
+  padding-top: 2px;
+`;
+
+const StyledEELogo = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: -6px;
+
+  .login {
+    margin-left: 9px;
+    font-size: 16px;
+  }
+`;
+const InfoBox = ({title = 'Example', children}) => {
+  return (
+    <div style={{position: 'relative', width: '100%', height: '100%'}}>
+      <StyledPanel>
+        <h2>
+          {title} <StyledEELogo />
+        </h2>
+        {children}
+        <br />
+        <br />
+        <small>
+          Note that to run this demo, you need to sign in with an
+          <a href="https://earthengine.google.com/new_signup/"> Earth Engine-enabled </a>
+          Google Account, and that loading EE data may take some time.
+        </small>
+      </StyledPanel>
+    </div>
+  );
+};
+
+export default InfoBox;


### PR DESCRIPTION
The login issues are most likely a result of componentDidMount not being called due to [server side rendering](https://jaketrent.com/post/react-componentdidmount-not-called-server-render/) in Gatsby builds.

I moved it back into constructor - this can cause issues if the auto login fires very quickly and the component hasn't been mounted, as setState is only allowed after mount. But this should only happen occasionally in development and the focus right now is to get a working build.

Added info box to Image example - should be duplicated for all examples

<img width="418" alt="Screen Shot 2020-05-22 at 8 05 51 AM" src="https://user-images.githubusercontent.com/7025232/82681820-2c486b80-9c03-11ea-8c5a-95a1a7b738dc.png">
