### PR TITLE
Run _updateEEVisParams if changed eeObject

### DIFF
--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -109,7 +109,7 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   async _updateEEVisParams(props, oldProps, changeFlags) {
-    if (props.visParams === oldProps.visParams && !changeFlags.dataChanged) {
+    if (props.visParams === oldProps.visParams && props.eeObject === oldProps.eeObject) {
       return;
     }
     const {animate, asVector, selectors} = props;

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -81,7 +81,6 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   _updateEEObject(props, oldProps, changeFlags) {
-    // if (!changeFlags.dataChanged) - TODO - we are not using data
     if (props.eeObject === oldProps.eeObject) {
       return;
     }


### PR DESCRIPTION
Closes #63 

In some occasions, either 

1. when rendering an image that's been styled using `.style` instead of `visParams` or
2. when rendering data as a vector

We need to call `updateEEVisParams` even if `visParams` hasn't changed. Since `changeFlags.dataChanged` means nothing since we aren't using the `data` prop, this changes that to compare the current and previous `eeObject` prop.