### PR TITLE
Rename build-rollup to build

### DIFF
--- a/modules/earthengine-layers/package.json
+++ b/modules/earthengine-layers/package.json
@@ -13,7 +13,7 @@
   },
   "main": "src/index.js",
   "scripts": {
-    "build-rollup": "rollup --config"
+    "build": "rollup --config"
   },
   "dependencies": {
     "@loaders.gl/core": "^2.1.2",


### PR DESCRIPTION
Since building the dist bundles is currently named `build-rollup` instead of `build`, it doesn't get called when `yarn build` is run in the root directory.