### PR TITLE
Update default bundle url for python package

### DIFF
--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -6,7 +6,7 @@ import ee
 import pydeck as pdk
 import requests
 
-EARTHENGINE_LAYER_BUNDLE_URL = 'https://cdn.jsdelivr.net/gh/UnfoldedInc/earthengine-layers@master/modules/earthengine-layers/dist/pydeck_layer_module.min.js'
+EARTHENGINE_LAYER_BUNDLE_URL = 'https://unpkg.com/@unfolded.gl/earthengine-layers/dist/pydeck_layer_module.min.js'
 
 
 class EarthEngineLayer(pdk.Layer):


### PR DESCRIPTION
The `modules/earthengine-layers/dist` folder was deleted from Github upon publishing the first betas to NPM. This updates the python module to point to the latest release on NPM, via unpkg.