### PR TITLE
Add new pydeck examples

### DIFF
--- a/py/examples/Introduction.ipynb
+++ b/py/examples/Introduction.ipynb
@@ -13,18 +13,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
-    "```\n",
+    "To run this notebook locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, make sure you have [Conda installed](https://www.anaconda.com/products/individual), then run:\n",
+    "\n",
+    "```bash\n",
     "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
     "conda activate pydeck-ee\n",
     "\n",
     "# Install the pydeck-earthengine-layers package from pip\n",
     "pip install pydeck-earthengine-layers\n",
     "\n",
+    "# If using Jupyter Notebook:\n",
     "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
     "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "\n",
+    "# If using Jupyter Lab\n",
+    "jupyter labextension install @jupyter-widgets/jupyterlab-manager\n",
+    "DECKGL_SEMVER=`python -c \"import pydeck; print(pydeck.frontend_semver.DECKGL_SEMVER)\"`\n",
+    "jupyter labextension install @deck.gl/jupyter-widget@$DECKGL_SEMVER\n",
     "```\n",
-    "then open Jupyter Notebook with `jupyter notebook`."
+    "\n",
+    "then open Jupyter Notebook with `jupyter notebook` or Jupyter Lab with `jupyter lab`."
    ]
   },
   {
@@ -36,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,8 +57,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Authentication\n",
-    "\n",
     "### Authenticate with Earth Engine\n",
     "\n",
     "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
@@ -60,14 +66,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
-    "\n",
-    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
+    "If you haven't used Earth Engine in Python before, the next block will create a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then restart the notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -84,23 +88,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Initialize Earth Engine\n",
+    "### Elevation data example\n",
     "\n",
-    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Elevation data example\n",
+    "Now let's make a simple example using [Shuttle Radar Topography Mission (SRTM)][srtm] elevation data. Here we create an `ee.Image` object referencing that dataset.\n",
     "\n",
-    "Now let's make a simple example using Shuttle Radar Topography Mission (SRTM) elevation data. Here we create an `ee.Image` object referencing that dataset."
+    "[srtm]: https://developers.google.com/earth-engine/datasets/catalog/CGIAR_SRTM90_V4"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,22 +108,48 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we're ready to create the Pydeck layer. The `EarthEngineLayer` makes this simple. Just pass the Earth Engine object to the class."
+    "Here `vis_params` consists of parameters that will be passed to the Earth Engine [`visParams` argument][visparams]. Any parameters that you could pass directly to Earth Engine in the code editor, you can also pass here to the `EarthEngineLayer`.\n",
+    "\n",
+    "[visparams]: https://developers.google.com/earth-engine/image_visualization"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis_params={\n",
+    "    \"min\": 0, \n",
+    "    \"max\": 4000,\n",
+    "    \"palette\": ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5']\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to create the Pydeck layer. The `EarthEngineLayer` makes this simple. Just pass the Earth Engine object to the class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Including the `id` argument isn't necessary when you only have one pydeck layer, but it is necessary to distinguish multiple layers, so it's good to get into the habit of including an `id` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "ee_layer = EarthEngineLayer(\n",
     "    image,\n",
-    "    vis_params={\n",
-    "        \"min\": 0, \n",
-    "        \"max\": 4000,\n",
-    "        'palette': ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5']\n",
-    "    }\n",
+    "    vis_params,\n",
+    "    id=\"SRTM_layer\"\n",
     ")"
    ]
   },
@@ -139,24 +162,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "762847d836764c6a86d7a42549863eed",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view_state = pdk.ViewState(latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45)\n",
     "r = pdk.Deck(\n",
@@ -172,16 +180,17 @@
    "source": [
     "## Hillshade Example\n",
     "\n",
-    "As a slightly more in-depth example, let's use the SRTM dataset to calculate hillshading. This example comes from "
+    "As a slightly more in-depth example, let's use the SRTM dataset to calculate hillshading. This example comes from [giswqs/earthengine-py-notebooks][giswqs/earthengine-py-notebooks]:\n",
+    "\n",
+    "[giswqs/earthengine-py-notebooks]: https://github.com/giswqs/earthengine-py-notebooks/blob/master/Visualization/hillshade.ipynb"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# From https://github.com/giswqs/earthengine-py-notebooks/blob/master/Visualization/hillshade.ipynb\n",
     "# Add Earth Engine dataset\n",
     "import math\n",
     "\n",
@@ -207,26 +216,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "06877f8d1ae04fd48ccccb4a303795d7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ee_object = Hillshade(0, 60, slope_img, aspect_img)\n",
     "ee_layer = EarthEngineLayer(ee_object)\n",

--- a/py/examples/international_boundaries.ipynb
+++ b/py/examples/international_boundaries.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pydeck Earth Engine Introduction\n",
+    "\n",
+    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
+    "```\n",
+    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
+    "conda activate pydeck-ee\n",
+    "\n",
+    "# Install the pydeck-earthengine-layers package from pip\n",
+    "pip install pydeck-earthengine-layers\n",
+    "\n",
+    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
+    "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "```\n",
+    "then open Jupyter Notebook with `jupyter notebook`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now in a Python Jupyter Notebook, let's first import required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydeck_earthengine_layers import EarthEngineLayer\n",
+    "import pydeck as pdk\n",
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "### Authenticate with Earth Engine\n",
+    "\n",
+    "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
+    "\n",
+    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ee.Initialize()\n",
+    "except Exception as e:\n",
+    "    ee.Authenticate()\n",
+    "    ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Earth Engine\n",
+    "\n",
+    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power plants visualization\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = ee.FeatureCollection('USDOS/LSIB_SIMPLE/2017')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countries = dataset.style(\n",
+    "    fillColor='b5ffb4',\n",
+    "    color='00909F',\n",
+    "    width=3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer = EarthEngineLayer(\n",
+    "    countries, \n",
+    "    library_url=\"https://unpkg.com/@unfolded.gl/earthengine-layers@1.0.0-beta.3/dist/pydeck_layer_module.min.js\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4c2e8eed4d543379321e3e52b80d87a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://unpkg.com/@u…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=36, longitude=10, zoom=3)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[layer], \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/py/examples/international_boundaries.ipynb
+++ b/py/examples/international_boundaries.ipynb
@@ -4,39 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pydeck Earth Engine Introduction\n",
+    "# Pydeck + Earth Engine: Polygon FeatureCollection\n",
     "\n",
-    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+    "This is an example of using Google Earth Engine to visualize a `FeatureCollection` of polygons in [Pydeck](https://pydeck.gl). To install and run this notebook locally, refer to the [Pydeck Earth Engine documentation](https://earthengine-layers.com/docs/developer-guide/pydeck-integration)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
-    "```\n",
-    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
-    "conda activate pydeck-ee\n",
-    "\n",
-    "# Install the pydeck-earthengine-layers package from pip\n",
-    "pip install pydeck-earthengine-layers\n",
-    "\n",
-    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
-    "jupyter nbextension enable --sys-prefix --py pydeck\n",
-    "```\n",
-    "then open Jupyter Notebook with `jupyter notebook`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now in a Python Jupyter Notebook, let's first import required packages:"
+    "Import required packages:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,25 +31,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Authentication\n",
-    "\n",
     "### Authenticate with Earth Engine\n",
     "\n",
     "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
-    "\n",
-    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -84,22 +55,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Initialize Earth Engine\n",
+    "### International Boundaries dataset\n",
     "\n",
-    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
+    "This example uses the [Large Scale International Boundary Polygons][lsib] dataset, which contains simplified boundaries of countries.\n",
+    "\n",
+    "[lsib]: https://developers.google.com/earth-engine/datasets/catalog/USDOS_LSIB_SIMPLE_2017"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Power plants visualization\n",
-    "\n"
+    "Import the dataset by creating an Earth Engine object that references it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,8 +79,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Apply Earth Engine styling on this dataset. Here we render the fill of the polygon with a shade of green, and the border color with a shade of blue."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,14 +99,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a new `EarthEngineLayer` with this dataset that can then be passed to Pydeck."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "layer = EarthEngineLayer(\n",
-    "    countries, \n",
-    "    library_url=\"https://unpkg.com/@unfolded.gl/earthengine-layers@1.0.0-beta.3/dist/pydeck_layer_module.min.js\")"
+    "layer = EarthEngineLayer(countries, id=\"international_boundaries\")"
    ]
   },
   {
@@ -139,24 +123,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c4c2e8eed4d543379321e3e52b80d87a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://unpkg.com/@u…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view_state = pdk.ViewState(latitude=36, longitude=10, zoom=3)\n",
     "r = pdk.Deck(\n",

--- a/py/examples/noaa_hurricanes.ipynb
+++ b/py/examples/noaa_hurricanes.ipynb
@@ -1,0 +1,342 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pydeck Earth Engine Introduction\n",
+    "\n",
+    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
+    "```\n",
+    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
+    "conda activate pydeck-ee\n",
+    "\n",
+    "# Install the pydeck-earthengine-layers package from pip\n",
+    "pip install pydeck-earthengine-layers\n",
+    "\n",
+    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
+    "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "```\n",
+    "then open Jupyter Notebook with `jupyter notebook`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now in a Python Jupyter Notebook, let's first import required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydeck_earthengine_layers import EarthEngineLayer\n",
+    "import pydeck as pdk\n",
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "### Authenticate with Earth Engine\n",
+    "\n",
+    "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
+    "\n",
+    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ee.Initialize()\n",
+    "except Exception as e:\n",
+    "    ee.Authenticate()\n",
+    "    ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Earth Engine\n",
+    "\n",
+    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## NOAA Hurricanes example\n",
+    "\n",
+    "Now let's make a simple example using Shuttle Radar Topography Mission (SRTM) elevation data. Here we create an `ee.Image` object referencing that dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hurricane tracks and points for 2017.\n",
+    "hurricanes = ee.FeatureCollection('NOAA/NHC/HURDAT2/atlantic')\n",
+    "\n",
+    "year = '2017'\n",
+    "points = hurricanes.filter(ee.Filter.date(ee.Date(year).getRange('year')))\n",
+    "\n",
+    "# Find all of the hurricane ids.\n",
+    "def get_id(point):\n",
+    "    return ee.Feature(point).get('id')\n",
+    "storm_ids = points.toList(1000).map(get_id).distinct()\n",
+    "\n",
+    "# Create a line for each hurricane.\n",
+    "def create_line(storm_id):\n",
+    "    pts = points.filter(ee.Filter.eq('id', ee.String(storm_id)))\n",
+    "    pts = pts.sort('system:time_start')\n",
+    "    line = ee.Geometry.LineString(pts.geometry().coordinates())\n",
+    "    feature = ee.Feature(line)\n",
+    "    return feature.set('id', storm_id)\n",
+    "\n",
+    "lines = ee.FeatureCollection(storm_ids.map(create_line))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to create the Pydeck layer. The `EarthEngineLayer` makes this simple. Just pass the Earth Engine object to the class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines_layer = EarthEngineLayer(\n",
+    "    lines,\n",
+    "    {'color': 'red'},\n",
+    "    id=\"tracks\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points_layer = EarthEngineLayer(\n",
+    "    points,\n",
+    "    {'color': 'black'},\n",
+    "    id=\"points\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd3db14a61194eee891c1b054ab2d555",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[points_layer, lines_layer], \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Vector\n",
+    "\n",
+    "Let's plot these again, but as a vector dataset, instead of a raster dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines_layer = EarthEngineLayer(\n",
+    "    lines,\n",
+    "    as_vector=True,\n",
+    "    get_line_color=[255, 0, 0],\n",
+    "    getLineWidth=1000,\n",
+    "    lineWidthMinPixels=3,\n",
+    "    id=\"tracks\",\n",
+    "    library_url=\"http://0.0.0.0:8003/pydeck_layer_module.min.js\"\n",
+    ")\n",
+    "points_layer = EarthEngineLayer(\n",
+    "    points,\n",
+    "    get_fill_color=[0, 0, 0],\n",
+    "    pointRadiusMinPixels=3,\n",
+    "    getRadius=100,\n",
+    "    getLineColor=[255, 255, 255],\n",
+    "    lineWidthMinPixels=0.5,\n",
+    "    as_vector=True,\n",
+    "    stroked=True,\n",
+    "    id=\"points\",\n",
+    "    library_url=\"http://0.0.0.0:8003/pydeck_layer_module.min.js\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3fd93eab9c7d4be9a2d0641695f6608b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[lines_layer, points_layer], \n",
+    "    initial_view_state=view_state,\n",
+    "    tooltip=True\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'Feature',\n",
+       " 'geometry': {'type': 'Point',\n",
+       "  'coordinates': [-75.19999691921689, 35.30000082489263]},\n",
+       " 'id': '000000000000000042fc',\n",
+       " 'properties': {'basin': 'AL',\n",
+       "  'datetime': '2004-08-03T18:00:00',\n",
+       "  'id': 'AL012004',\n",
+       "  'max_wind_kts': 85,\n",
+       "  'min_pressure': 972,\n",
+       "  'name': 'ALEX',\n",
+       "  'numEntries': 25,\n",
+       "  'radii_ne_34kt': 90,\n",
+       "  'radii_ne_50kt': 60,\n",
+       "  'radii_ne_64kt': 30,\n",
+       "  'radii_nw_34kt': 50,\n",
+       "  'radii_nw_50kt': 30,\n",
+       "  'radii_nw_64kt': 15,\n",
+       "  'radii_se_34kt': 90,\n",
+       "  'radii_se_50kt': 50,\n",
+       "  'radii_se_64kt': 30,\n",
+       "  'radii_sw_34kt': 75,\n",
+       "  'radii_sw_50kt': 30,\n",
+       "  'radii_sw_64kt': 20,\n",
+       "  'record_id': '',\n",
+       "  'seq': 1,\n",
+       "  'status': 'HU',\n",
+       "  'system:time_start': 1091556000000,\n",
+       "  'year': 2004}}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hurricanes.first().getInfo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/py/examples/noaa_hurricanes.ipynb
+++ b/py/examples/noaa_hurricanes.ipynb
@@ -4,39 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pydeck Earth Engine Introduction\n",
+    "# Pydeck + Earth Engine: Lines FeatureCollection\n",
     "\n",
-    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+    "This is an example of using Google Earth Engine to visualize a `FeatureCollection` of lines in [Pydeck](https://pydeck.gl). To install and run this notebook locally, refer to the [Pydeck Earth Engine documentation](https://earthengine-layers.com/docs/developer-guide/pydeck-integration)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
-    "```\n",
-    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
-    "conda activate pydeck-ee\n",
-    "\n",
-    "# Install the pydeck-earthengine-layers package from pip\n",
-    "pip install pydeck-earthengine-layers\n",
-    "\n",
-    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
-    "jupyter nbextension enable --sys-prefix --py pydeck\n",
-    "```\n",
-    "then open Jupyter Notebook with `jupyter notebook`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now in a Python Jupyter Notebook, let's first import required packages:"
+    "Import required packages:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,25 +31,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Authentication\n",
-    "\n",
     "### Authenticate with Earth Engine\n",
     "\n",
     "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
-    "\n",
-    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -84,23 +55,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Initialize Earth Engine\n",
+    "### NOAA Hurricanes dataset\n",
     "\n",
-    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## NOAA Hurricanes example\n",
+    "This example uses the [NOAA Atlantic Hurricane catalog][noaa], a dataset with positions of hurricanes and related attributes from 1851 to 2018. In this example we'll look only at hurricanes in 2017.\n",
     "\n",
-    "Now let's make a simple example using Shuttle Radar Topography Mission (SRTM) elevation data. Here we create an `ee.Image` object referencing that dataset."
+    "[noaa]: https://developers.google.com/earth-engine/datasets/catalog/NOAA_NHC_HURDAT2_atlantic"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,24 +132,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd3db14a61194eee891c1b054ab2d555",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
     "r = pdk.Deck(\n",
@@ -206,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +166,6 @@
     "    getLineWidth=1000,\n",
     "    lineWidthMinPixels=3,\n",
     "    id=\"tracks\",\n",
-    "    library_url=\"http://0.0.0.0:8003/pydeck_layer_module.min.js\"\n",
     ")\n",
     "points_layer = EarthEngineLayer(\n",
     "    points,\n",
@@ -229,30 +177,14 @@
     "    as_vector=True,\n",
     "    stroked=True,\n",
     "    id=\"points\",\n",
-    "    library_url=\"http://0.0.0.0:8003/pydeck_layer_module.min.js\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3fd93eab9c7d4be9a2d0641695f6608b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://cdn.jsdelivr…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
     "r = pdk.Deck(\n",
@@ -261,53 +193,6 @@
     "    tooltip=True\n",
     ")\n",
     "r.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'type': 'Feature',\n",
-       " 'geometry': {'type': 'Point',\n",
-       "  'coordinates': [-75.19999691921689, 35.30000082489263]},\n",
-       " 'id': '000000000000000042fc',\n",
-       " 'properties': {'basin': 'AL',\n",
-       "  'datetime': '2004-08-03T18:00:00',\n",
-       "  'id': 'AL012004',\n",
-       "  'max_wind_kts': 85,\n",
-       "  'min_pressure': 972,\n",
-       "  'name': 'ALEX',\n",
-       "  'numEntries': 25,\n",
-       "  'radii_ne_34kt': 90,\n",
-       "  'radii_ne_50kt': 60,\n",
-       "  'radii_ne_64kt': 30,\n",
-       "  'radii_nw_34kt': 50,\n",
-       "  'radii_nw_50kt': 30,\n",
-       "  'radii_nw_64kt': 15,\n",
-       "  'radii_se_34kt': 90,\n",
-       "  'radii_se_50kt': 50,\n",
-       "  'radii_se_64kt': 30,\n",
-       "  'radii_sw_34kt': 75,\n",
-       "  'radii_sw_50kt': 30,\n",
-       "  'radii_sw_64kt': 20,\n",
-       "  'record_id': '',\n",
-       "  'seq': 1,\n",
-       "  'status': 'HU',\n",
-       "  'system:time_start': 1091556000000,\n",
-       "  'year': 2004}}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "hurricanes.first().getInfo()"
    ]
   },
   {

--- a/py/examples/power_plants.ipynb
+++ b/py/examples/power_plants.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pydeck Earth Engine Introduction\n",
+    "\n",
+    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
+    "```\n",
+    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
+    "conda activate pydeck-ee\n",
+    "\n",
+    "# Install the pydeck-earthengine-layers package from pip\n",
+    "pip install pydeck-earthengine-layers\n",
+    "\n",
+    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
+    "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "```\n",
+    "then open Jupyter Notebook with `jupyter notebook`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now in a Python Jupyter Notebook, let's first import required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydeck_earthengine_layers import EarthEngineLayer\n",
+    "import pydeck as pdk\n",
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "### Authenticate with Earth Engine\n",
+    "\n",
+    "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
+    "\n",
+    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ee.Initialize()\n",
+    "except Exception as e:\n",
+    "    ee.Authenticate()\n",
+    "    ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Earth Engine\n",
+    "\n",
+    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power plants visualization\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the FeatureCollection\n",
+    "table = ee.FeatureCollection(\"WRI/GPPD/power_plants\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create color palette\n",
+    "fuel_color = ee.Dictionary({\n",
+    "  'Coal': '000000',\n",
+    "  'Oil': '593704',\n",
+    "  'Gas': 'BC80BD',\n",
+    "  'Hydro': '0565A6',\n",
+    "  'Nuclear': 'E31A1C',\n",
+    "  'Solar': 'FF7F00',\n",
+    "  'Waste': '6A3D9A',\n",
+    "  'Wind': '5CA2D1',\n",
+    "  'Geothermal': 'FDBF6F',\n",
+    "  'Biomass': '229A00'\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List of fuels to add to the map\n",
+    "fuels = ['Coal', 'Oil', 'Gas', 'Hydro', 'Nuclear', 'Solar', 'Waste',\n",
+    "    'Wind', 'Geothermal', 'Biomass']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_style(point):\n",
+    "    \"\"\"Computes size from capacity and color from fuel type.\n",
+    "    \n",
+    "    Args:\n",
+    "        - point: (ee.Geometry.Point) A Point\n",
+    "        \n",
+    "    Returns:\n",
+    "        (ee.Geometry.Point): Input point with added style dictionary\n",
+    "    \"\"\"\n",
+    "    size = ee.Number(point.get('capacitymw')).sqrt().divide(10).add(2)\n",
+    "    color = fuel_color.get(point.get('fuel1'))\n",
+    "    return point.set('styleProperty', ee.Dictionary({'pointSize': size, 'color': color}))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a FeatureCollection out of the power plant data table\n",
+    "pp = ee.FeatureCollection(table).map(add_style)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a layer for each fuel type\n",
+    "layers = []\n",
+    "for fuel in fuels:\n",
+    "    layer = EarthEngineLayer(\n",
+    "        pp.filter(ee.Filter.eq('fuel1', fuel)).style(styleProperty='styleProperty', neighborhood=50),\n",
+    "        id=fuel,\n",
+    "        opacity=0.65,\n",
+    "        library_url='https://unpkg.com/@unfolded.gl/earthengine-layers@1.0.0-beta.3/dist/pydeck_layer_module.min.js'\n",
+    "    )\n",
+    "    layers.append(layer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd0ba5ab338c4a04ac4ecf7ede9bb623",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://unpkg.com/@u…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
+    "r = pdk.Deck(\n",
+    "    layers=layers, \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/py/examples/power_plants.ipynb
+++ b/py/examples/power_plants.ipynb
@@ -4,39 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pydeck Earth Engine Introduction\n",
+    "# Pydeck + Earth Engine: Points FeatureCollection\n",
     "\n",
-    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks."
+    "This is an example of using Google Earth Engine to visualize a `FeatureCollection` of points in [Pydeck](https://pydeck.gl). To install and run this notebook locally, refer to the [Pydeck Earth Engine documentation](https://earthengine-layers.com/docs/developer-guide/pydeck-integration)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you wish to run this locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, run:\n",
-    "```\n",
-    "conda create -n pydeck-ee -c conda-forge python jupyter notebook pydeck earthengine-api requests -y\n",
-    "conda activate pydeck-ee\n",
-    "\n",
-    "# Install the pydeck-earthengine-layers package from pip\n",
-    "pip install pydeck-earthengine-layers\n",
-    "\n",
-    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
-    "jupyter nbextension enable --sys-prefix --py pydeck\n",
-    "```\n",
-    "then open Jupyter Notebook with `jupyter notebook`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now in a Python Jupyter Notebook, let's first import required packages:"
+    "Import required packages:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,25 +31,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Authentication\n",
-    "\n",
     "### Authenticate with Earth Engine\n",
     "\n",
     "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you haven't used Earth Engine in Python before, you'll need to run the following authentication command. If you've previously authenticated in Python or the command line, you can skip the next line.\n",
-    "\n",
-    "Note that this creates a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then return here, skipping the Python authentication."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -84,22 +55,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Initialize Earth Engine\n",
+    "### Power plants dataset\n",
     "\n",
-    "The above authentication step creates credentials that are stored on your local computer. Those credentials need to be loaded so that Earth Engine and Pydeck will work."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Power plants visualization\n",
-    "\n"
+    "This example uses the [Global Power Plant Database][dataset], which contains location of power plants around the world, as well as metadata of which fuel source is used, and how much energy is created.\n",
+    "\n",
+    "[dataset]: https://developers.google.com/earth-engine/datasets/catalog/WRI_GPPD_power_plants\n",
+    "\n",
+    "First we'll render using EarthEngine's native capabilities, then we'll render using pydeck's rich data-driven styling capabilities."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,24 +163,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd0ba5ab338c4a04ac4ecf7ede9bb623",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'https://unpkg.com/@u…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
     "r = pdk.Deck(\n",

--- a/py/examples/power_plants.ipynb
+++ b/py/examples/power_plants.ipynb
@@ -149,7 +149,6 @@
     "        pp.filter(ee.Filter.eq('fuel1', fuel)).style(styleProperty='styleProperty', neighborhood=50),\n",
     "        id=fuel,\n",
     "        opacity=0.65,\n",
-    "        library_url='https://unpkg.com/@unfolded.gl/earthengine-layers@1.0.0-beta.3/dist/pydeck_layer_module.min.js'\n",
     "    )\n",
     "    layers.append(layer)"
    ]
@@ -159,6 +158,85 @@
    "metadata": {},
    "source": [
     "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_state = pdk.ViewState(latitude=36, longitude=-53, zoom=3)\n",
+    "r = pdk.Deck(\n",
+    "    layers=layers, \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Vector rendering\n",
+    "\n",
+    "To experience the full potential of pydeck, we need to explore rendering the data with vector output. Rendering the data as a vector allows for client-side data driven styling and picking objects to get information on each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuel_color = {\n",
+    "  'Coal': [0, 0, 0],\n",
+    "  'Oil': [89, 55, 4],\n",
+    "  'Gas': [188, 128, 189],\n",
+    "  'Hydro': [5, 101, 166],\n",
+    "  'Nuclear': [227, 26, 28],\n",
+    "  'Solar': [255, 127, 0],\n",
+    "  'Waste': [106, 61, 154],\n",
+    "  'Wind': [92, 162, 209],\n",
+    "  'Geothermal': [253, 191, 111],\n",
+    "  'Biomass': [34, 154, 0],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layers = []\n",
+    "for fuel in fuels:\n",
+    "    layer = EarthEngineLayer(\n",
+    "        # Create each layer as consisting of a single fuel type\n",
+    "        table.filter(ee.Filter.eq('fuel1', fuel)),\n",
+    "        vis_params={},\n",
+    "        # Define a custom radius\n",
+    "        getRadius='.properties.capacitymw ** 1.35',\n",
+    "        lineWidthMinPixels=0.5,\n",
+    "        pointRadiusMinPixels=2,\n",
+    "        # Use dictionary for color mapping\n",
+    "        get_fill_color=fuel_color[fuel],\n",
+    "        # Provide a list of extra dataset properties that should be downloaded for rendering\n",
+    "        # Without this, only the geometry will be downloaded\n",
+    "        selectors=['capacitymw'],\n",
+    "        # Render as a vector, instead of as a raster generated on EE's servers\n",
+    "        as_vector=True,\n",
+    "        id=fuel,\n",
+    "        opacity=0.65,\n",
+    "    )\n",
+    "    layers.append(layer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just as before, we define a `ViewState` and pass these layers to the `Deck` object."
    ]
   },
   {


### PR DESCRIPTION
Adds three new pydeck examples. These need to be cleaned up a little more

- [x] Each notebook has a bit of documentation regarding how to install the package and authenticate. This is repetitive in each notebook, so maybe it should be removed from most (all?) notebooks and discussed just in docs? Or include only in the notebook named `Introduction.ipynb`.
- [x] Remove custom `library_url` argument. The latest release on NPM is missing the built pydeck module.
- [x] Test out rendering the power plants example (point FeatureCollection) as vector. I don't know how large that dataset would be.