### PR TITLE
Fix tooltip flicker

### DIFF
--- a/examples/power-plants/app.js
+++ b/examples/power-plants/app.js
@@ -32,14 +32,6 @@ const FUEL_COLOR_MAPPING_VECTOR = {
 };
 
 class Tooltip extends React.Component {
-  // Lessen flashing by only updating when name changes
-  shouldComponentUpdate(nextProps, nextState) {
-    if (this.props.hoveredObject.properties.name === nextProps.hoveredObject.properties.name) {
-      return false;
-    }
-    return true;
-  }
-
   render() {
     const {hoveredObject, x, y} = this.props;
     return (
@@ -133,7 +125,7 @@ export default class App extends React.Component {
           pickingRadius={10}
           googleMapsToken={GOOGLE_MAPS_TOKEN}
         />
-        {hoveredObject && <Tooltip x={x} y={y} hoveredObject={hoveredObject} />}
+        {hoveredObject && <Tooltip x={x + 2} y={y + 2} hoveredObject={hoveredObject} />}
 
         <GoogleLoginPane loginProvider={this.loginProvider} />
         <InfoBox title="FeatureCollection">


### PR DESCRIPTION
For some reason it seems the tooltip div ends up interfering with the pointer, not sure why this became an issue after the switch to Google Maps but a small offset seems to solve it.