### PR TITLE
Bump @loaders.gl to 2.3.0-alpha.10

### DIFF
--- a/modules/earthengine-layers/package.json
+++ b/modules/earthengine-layers/package.json
@@ -16,9 +16,9 @@
     "build": "rollup --config"
   },
   "dependencies": {
-    "@loaders.gl/core": "^2.1.2",
-    "@loaders.gl/images": "^2.1.2",
-    "@loaders.gl/json": "^2.1.6",
+    "@loaders.gl/core": "2.3.0-alpha.10",
+    "@loaders.gl/images": "2.3.0-alpha.10",
+    "@loaders.gl/json": "2.3.0-alpha.10",
     "@math.gl/web-mercator": "3.1.2"
   },
   "devDependencies": {

--- a/modules/earthengine-layers/rollup.config.js
+++ b/modules/earthengine-layers/rollup.config.js
@@ -25,8 +25,7 @@ const config = ({file, plugins = [], globals = {}, external = []}) => ({
     '@luma.gl/engine',
     '@luma.gl/gltools',
     '@luma.gl/webgl',
-    '@loaders.gl/core',
-    '@loaders.gl/loader-utils'
+    '@loaders.gl/core'
   ],
   plugins: [
     ...plugins,

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     "react-map-gl": "^5.1.0",
     "reify": "^0.18.1"
   },
+  "resolutions": {
+    "@loaders.gl/core": "2.3.0-alpha.10",
+    "@loaders.gl/images": "2.3.0-alpha.10",
+    "@loaders.gl/json": "2.3.0-alpha.10",
+    "@loaders.gl/loader-utils": "2.3.0-alpha.10"
+  },
   "pre-commit": [
     "test-fast"
   ]

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     "@deck.gl/layers": "^8.2.5",
     "@deck.gl/mesh-layers": "^8.2.5",
     "@deck.gl/react": "^8.2.5",
-    "@loaders.gl/core": "^2.1.1",
+    "@loaders.gl/core": "^2.3.0-alpha.10",
     "@luma.gl/constants": "^8.2.0",
     "@luma.gl/core": "^8.2.0",
     "@luma.gl/experimental": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,13 +1812,13 @@
     "@math.gl/geospatial" "^3.2.0"
     "@probe.gl/stats" "^3.3.0"
 
-"@loaders.gl/core@2.2.8", "@loaders.gl/core@^2.1.2", "@loaders.gl/core@^2.2.3":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.2.8.tgz#fb2060f3b90d3babe0de2a128fc5227f921c08ad"
-  integrity sha512-PM74zQA6Kn6NJCMoRdEDENy9jQWQyMkICKZ6o8UGa6/oi3dD4LO5GhFZSwU6W/Lxl/IeUwaZBQ3MqfT3aXA0Dg==
+"@loaders.gl/core@2.2.8", "@loaders.gl/core@2.3.0-alpha.10", "@loaders.gl/core@^2.2.3":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.3.0-alpha.10.tgz#bd58888c85c424dde136c7f798440c8f5b597be8"
+  integrity sha512-rkuO0CxzIjJv52AVEhkDNdh9Xm9tyyZs15agM8rYPsV7ScgeBECVlM5tE702SwbwGsZvPBFHK5mqp2c8zuaLlg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "2.2.8"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
 
 "@loaders.gl/draco@2.2.8":
   version "2.2.8"
@@ -1828,6 +1828,15 @@
     "@babel/runtime" "^7.3.1"
     "@loaders.gl/loader-utils" "2.2.8"
     draco3d "^1.3.4"
+
+"@loaders.gl/gis@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-2.3.0-alpha.10.tgz#ef9bfed3fa93ae751b6c6a1966660cc3f7435f21"
+  integrity sha512-jEMa8lC/Nem7r6woS/LO8quoDc+iGHmFZ/6F16Vt4+B+HLtpoLM0BzUpb6qIlprvdcDb7Az2+25Wjn91NzheRg==
+  dependencies:
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
+    "@mapbox/vector-tile" "^1.3.1"
+    pbf "^3.2.1"
 
 "@loaders.gl/gltf@2.2.8":
   version "2.2.8"
@@ -1839,25 +1848,26 @@
     "@loaders.gl/images" "2.2.8"
     "@loaders.gl/loader-utils" "2.2.8"
 
-"@loaders.gl/images@2.2.8", "@loaders.gl/images@^2.1.2", "@loaders.gl/images@^2.2.3":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.2.8.tgz#7db7781fcc3aa60f3cf1109370ea87ac5bf78ad0"
-  integrity sha512-qFKdtD8Wo7wmqFJsaqBm5owrzl2vDMlTYzGaqnpNjqVCEmjp8f6mj+511FyXmE4vuPqiC/zOFg/pAKXi39bHRQ==
+"@loaders.gl/images@2.2.8", "@loaders.gl/images@2.3.0-alpha.10", "@loaders.gl/images@^2.2.3":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.3.0-alpha.10.tgz#abebdb5fde927cd6e96f9da782a7dd55525f0bc4"
+  integrity sha512-iP7o7ZBO7RhsMHinsiHFeovnx0RzzXqf/4DeWGKDkuSZ6gbqXXtMVnh0HlNg84Jv50iyi7D1gZAIKi2DoqkmrQ==
   dependencies:
-    "@loaders.gl/loader-utils" "2.2.8"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
 
-"@loaders.gl/json@^2.1.6":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/json/-/json-2.2.8.tgz#18765df7f426306940fa546b5b9e95b6831c3dab"
-  integrity sha512-15d4bmMtUd/TGydC1HbBn46uZlvXI5YK49GC5HWNu4SMqruvv7J/yWRWRViCP1klYv2ls2lHapgv9qQM8ug/7Q==
+"@loaders.gl/json@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/json/-/json-2.3.0-alpha.10.tgz#907b9cc7847aeda74a1d8b7a9addb89b9272e543"
+  integrity sha512-O5XyXJnNKQH6PGtH6eJCwLTr783hARtmRaWP4EVwB3eqBMROW9fD5KyEdjmiQafqP8YAE4uOGymzuEMvq8VvKQ==
   dependencies:
-    "@loaders.gl/loader-utils" "2.2.8"
-    "@loaders.gl/tables" "2.2.8"
+    "@loaders.gl/gis" "2.3.0-alpha.10"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
+    "@loaders.gl/tables" "2.3.0-alpha.10"
 
-"@loaders.gl/loader-utils@2.2.8", "@loaders.gl/loader-utils@^2.2.3":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.2.8.tgz#9f12f3460260b15e961fa46c3d3c867d7bf48bee"
-  integrity sha512-3F2VgxJPxjuZwAr8fDBkZzx3Wg275XdVaWnyYQ3uyZQ22yGEkrzKc+TlgcqSrxbO5pHrtS5PdS7dmyoJo2+Bdg==
+"@loaders.gl/loader-utils@2.2.8", "@loaders.gl/loader-utils@2.3.0-alpha.10", "@loaders.gl/loader-utils@^2.2.3":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.3.0-alpha.10.tgz#b5639e2ae50e827ff552fefe5589f19f2e18f4f0"
+  integrity sha512-+wn7TwLtzDt25OJT+Qc5ZIcBnhuSh76b8HELVsg/XVPC/A+2YcFKD8yKQdCpASvHprcdz7+iwhypZm9HpNTjiQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@probe.gl/stats" "^3.3.0"
@@ -1880,12 +1890,12 @@
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
-"@loaders.gl/tables@2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.2.8.tgz#217d494724f5ee9b64b40a149b8fe53ad26fdf07"
-  integrity sha512-FmOytFxljfZbtZvWpjNz1//Yedk/k7ZRf0Aj1P/fFxgZzAtf6BclvOt+Vf6XiDY2vjGGbAkcaF0nlOqbvSc0Hw==
+"@loaders.gl/tables@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.3.0-alpha.10.tgz#963854466f4ec11854f54c686a2992d3ec77dde5"
+  integrity sha512-DFVBvSYJh40yie+zjJqS3cyZVK1FOJ07trcMe/Unj3RDfFwCHPIbm0OiXmeTVZR7GoPeX67zpgJS5sggCGuP5g==
   dependencies:
-    "@loaders.gl/core" "2.2.8"
+    "@loaders.gl/core" "2.3.0-alpha.10"
 
 "@loaders.gl/terrain@^2.2.3":
   version "2.2.8"


### PR DESCRIPTION
Fixes Node imports within loaders.gl so that the latest JS bundle can be used successfully in pydeck.