### PR TITLE
Pydeck EarthEngineTerrainLayer

### DIFF
--- a/modules/earthengine-layers/docs/api-reference/earthengine-layer.md
+++ b/modules/earthengine-layers/docs/api-reference/earthengine-layer.md
@@ -72,15 +72,15 @@ new EarthEngineLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.2.0/dist.min.js"></script>
 <script src="https://unpkg.com/@google/earthengine@^0.1.221/build/ee_api_js.js"></script>
-<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^0.1.0/dist.min.js"></script>
+<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^1.1.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.2.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.2.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.2.0/dist.min.js"></script>
 <script src="https://unpkg.com/@google/earthengine@^0.1.221/build/ee_api_js.js"></script>
-<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^0.1.0/dist.min.js"></script>
+<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^1.1.0/dist.min.js"></script>
 ```
 
 ```js

--- a/modules/earthengine-layers/docs/api-reference/earthengine-terrain-layer.md
+++ b/modules/earthengine-layers/docs/api-reference/earthengine-terrain-layer.md
@@ -77,15 +77,16 @@ new EarthEngineTerrainLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.2.0/dist.min.js"></script>
 <script src="https://unpkg.com/@google/earthengine@^0.1.221/build/ee_api_js.js"></script>
-<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^0.1.0/dist.min.js"></script>
+<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^1.1.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.2.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.2.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.2.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/mesh-layers@^8.2.0/dist.min.js"></script>
 <script src="https://unpkg.com/@google/earthengine@^0.1.221/build/ee_api_js.js"></script>
-<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^0.1.0/dist.min.js"></script>
+<script src="https://unpkg.com/@unfolded.gl/earthengine-layers@^1.1.0/dist.min.js"></script>
 ```
 
 ```js

--- a/modules/earthengine-layers/package.json
+++ b/modules/earthengine-layers/package.json
@@ -22,7 +22,7 @@
     "@math.gl/web-mercator": "3.1.2"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "rollup": "^2.4.0",

--- a/modules/earthengine-layers/rollup.config.js
+++ b/modules/earthengine-layers/rollup.config.js
@@ -31,8 +31,13 @@ const config = ({file, plugins = [], globals = {}, external = []}) => ({
   ]
 });
 
-// TODO: What globals should we assume for the main ee bundle?
-const eeGlobals = {'@google/earthengine': 'ee'}
+const eeGlobals = {
+  '@google/earthengine': 'ee',
+  '@deck.gl/core': 'deck',
+  '@deck.gl/geo-layers': 'deck',
+  '@deck.gl/layers': 'deck',
+  '@deck.gl/mesh-layers': 'deck'
+};
 
 // deck.gl globals provided by pydeck. See:
 // https://github.com/visgl/deck.gl/blob/c8702ae134e0598b2fdca03642744f25e9de593b/modules/jupyter-widget/src/deck-bundle.js

--- a/modules/earthengine-layers/rollup.config.js
+++ b/modules/earthengine-layers/rollup.config.js
@@ -12,14 +12,12 @@ const config = ({file, plugins = [], globals = {}, external = []}) => ({
     globals: {
       ...globals,
       '@deck.gl/core': 'deck',
-      '@deck.gl/layers': 'deck',
       '@loaders.gl/core': 'loaders'
     }
   },
   external: [
     ...external,
     '@deck.gl/core',
-    '@deck.gl/layers',
     '@loaders.gl/core'
   ],
   plugins: [
@@ -33,23 +31,42 @@ const config = ({file, plugins = [], globals = {}, external = []}) => ({
   ]
 });
 
+// TODO: What globals should we assume for the main ee bundle?
+const eeGlobals = {'@google/earthengine': 'ee'}
+
+// deck.gl globals provided by pydeck. See:
+// https://github.com/visgl/deck.gl/blob/c8702ae134e0598b2fdca03642744f25e9de593b/modules/jupyter-widget/src/deck-bundle.js
+const pydeckGlobals = {
+  '@deck.gl/aggregation-layers': 'deck',
+  '@deck.gl/core': 'deck',
+  '@deck.gl/geo-layers': 'deck',
+  '@deck.gl/google-maps': 'deck',
+  '@deck.gl/json': 'deck',
+  '@deck.gl/layers': 'deck',
+  '@deck.gl/mesh-layers': 'deck'
+};
+
 export default [
   config({
     file: 'dist/dist.js',
-    globals: {'@google/earthengine': 'ee'},
-    external: ['@google/earthengine']
+    globals: eeGlobals,
+    external: Object.keys(eeGlobals)
   }),
   config({
     file: 'dist/dist.min.js',
     plugins: [terser()],
-    globals: {'@google/earthengine': 'ee'},
-    external: ['@google/earthengine']
+    globals: eeGlobals,
+    external: Object.keys(eeGlobals)
   }),
   config({
-    file: 'dist/pydeck_layer_module.js'
+    file: 'dist/pydeck_layer_module.js',
+    globals: pydeckGlobals,
+    external: Object.keys(pydeckGlobals)
   }),
   config({
     file: 'dist/pydeck_layer_module.min.js',
+    globals: pydeckGlobals,
+    external: Object.keys(pydeckGlobals),
     plugins: [terser()]
   })
 ];

--- a/modules/earthengine-layers/rollup.config.js
+++ b/modules/earthengine-layers/rollup.config.js
@@ -13,7 +13,6 @@ const config = ({file, plugins = [], globals = {}, external = []}) => ({
       ...globals,
       '@deck.gl/core': 'deck',
       '@deck.gl/layers': 'deck',
-      '@luma.gl/core': 'luma',
       '@loaders.gl/core': 'loaders'
     }
   },
@@ -21,10 +20,6 @@ const config = ({file, plugins = [], globals = {}, external = []}) => ({
     ...external,
     '@deck.gl/core',
     '@deck.gl/layers',
-    '@luma.gl/core',
-    '@luma.gl/engine',
-    '@luma.gl/gltools',
-    '@luma.gl/webgl',
     '@loaders.gl/core'
   ],
   plugins: [

--- a/modules/earthengine-layers/src/bundle.js
+++ b/modules/earthengine-layers/src/bundle.js
@@ -1,7 +1,9 @@
 /* global window, global */
 import EarthEngineLayer from './earth-engine-layer';
+import EarthEngineTerrainLayer from './earth-engine-terrain-layer';
 const EarthEngineLayerLibrary = {
-  EarthEngineLayer
+  EarthEngineLayer,
+  EarthEngineTerrainLayer
 };
 
 const _global = typeof window === 'undefined' ? global : window;

--- a/modules/earthengine-layers/src/earth-engine-terrain-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-terrain-layer.js
@@ -7,7 +7,7 @@ import {deepEqual, promisifyEEMethod} from './utils';
 /**
  * Decoder for Terrarium encoding
  */
-export const ELEVATION_DECODER = {
+const ELEVATION_DECODER = {
   rScaler: 256,
   gScaler: 1,
   bScaler: 1 / 256,

--- a/py/examples/terrain.ipynb
+++ b/py/examples/terrain.ipynb
@@ -4,51 +4,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pydeck Earth Engine Introduction\n",
+    "# Pydeck + Earth Engine: Terrain Visualization\n",
     "\n",
-    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks.\n",
+    "This is an example of using [pydeck](https://pydeck.gl) to visualize a Google Earth Engine `Image` object _over 3D terrain_. To install and run this notebook locally, refer to the [Pydeck Earth Engine documentation](https://earthengine-layers.com/docs/developer-guide/pydeck-integration).\n",
     "\n",
     "To see this example online, view the [JavaScript version][js-example].\n",
     "\n",
-    "[js-example]: https://earthengine-layers.com/examples/image"
+    "[js-example]: https://earthengine-layers.com/examples/terrain"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To run this notebook locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, make sure you have [Conda installed](https://www.anaconda.com/products/individual), then run:\n",
-    "\n",
-    "```bash\n",
-    "conda create -n pydeck-ee -c conda-forge python jupyter jupyterlab notebook pydeck earthengine-api nodejs -y\n",
-    "conda activate pydeck-ee\n",
-    "\n",
-    "# Install the pydeck-earthengine-layers package from pip\n",
-    "pip install pydeck-earthengine-layers\n",
-    "\n",
-    "# If using Jupyter Notebook:\n",
-    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
-    "jupyter nbextension enable --sys-prefix --py pydeck\n",
-    "\n",
-    "# If using Jupyter Lab\n",
-    "jupyter labextension install @jupyter-widgets/jupyterlab-manager\n",
-    "DECKGL_SEMVER=`python -c \"import pydeck; print(pydeck.frontend_semver.DECKGL_SEMVER)\"`\n",
-    "jupyter labextension install @deck.gl/jupyter-widget@$DECKGL_SEMVER\n",
-    "```\n",
-    "\n",
-    "then open Jupyter Notebook with `jupyter notebook` or Jupyter Lab with `jupyter lab`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now in a Python Jupyter Notebook, let's first import required packages:"
+    "First, import required packages. Note that here we import the `EarthEngineTerrainLayer` instead of the `EarthEngineLayer`, as in other examples."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,15 +41,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you haven't used Earth Engine in Python before, the next block will create a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then restart the notebook."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -92,20 +59,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Elevation data example\n",
+    "### Terrain Example\n",
     "\n",
-    "Now let's make a simple example using [Shuttle Radar Topography Mission (SRTM)][srtm] elevation data. Here we create an `ee.Image` object referencing that dataset.\n",
+    "In contrast to the `EarthEngineLayer`, where you need to supply _one_ Earth Engine object to render, with the `EarthEngineTerrainLayer` you must supply **two** Earth Engine objects. The first is used to render the image in the same way as the `EarthEngineLayer`; the second supplies elevation values used to extrude terrain in the third dimension. Hence the former can be any `Image` object; the latter must be an `Image` object whose values represents terrain heights.\n",
     "\n",
-    "[srtm]: https://developers.google.com/earth-engine/datasets/catalog/CGIAR_SRTM90_V4"
+    "It's important for the terrain source to have relatively high spatial resolution. In previous examples, we used [SRTM90][srtm90] as an elevation source, but that only has a resolution of 90 meters. When used as an elevation source, it looks very blocky/pixelated at high zoom levels. In this example we'll use [SRTM30][srtm30] (30-meter resolution) as the `Image` source and the [USGS's National Elevation Dataset][ned] (10-meter resolution, U.S. only) as the terrain source. SRTM30 is generally the best-resolution worldwide data source available.\n",
+    "\n",
+    "[srtm90]: https://developers.google.com/earth-engine/datasets/catalog/CGIAR_SRTM90_V4\n",
+    "[srtm30]: https://developers.google.com/earth-engine/datasets/catalog/USGS_SRTMGL1_003\n",
+    "[ned]: https://developers.google.com/earth-engine/datasets/catalog/USGS_NED"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = ee.Image('CGIAR/SRTM90_V4')\n",
+    "image = ee.Image('USGS/SRTMGL1_003').select('elevation')\n",
     "terrain = ee.Image('USGS/NED').select('elevation')"
    ]
   },
@@ -120,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,84 +140,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "13a4a01c4f9a4d0183749653bbbe3b96",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'http://localhost:800…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "view_state = pdk.ViewState(latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45)\n",
-    "r = pdk.Deck(\n",
-    "    layers=[ee_layer], \n",
-    "    initial_view_state=view_state\n",
-    ")\n",
-    "r.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Hillshade Example\n",
-    "\n",
-    "As a slightly more in-depth example, let's use the SRTM dataset to calculate hillshading. This example comes from [giswqs/earthengine-py-notebooks][giswqs/earthengine-py-notebooks]:\n",
-    "\n",
-    "[giswqs/earthengine-py-notebooks]: https://github.com/giswqs/earthengine-py-notebooks/blob/master/Visualization/hillshade.ipynb"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add Earth Engine dataset\n",
-    "import math\n",
-    "\n",
-    "def Radians(img):\n",
-    "  return img.toFloat().multiply(math.pi).divide(180)\n",
-    "\n",
-    "def Hillshade(az, ze, slope, aspect):\n",
-    "  \"\"\"Compute hillshade for the given illumination az, el.\"\"\"\n",
-    "  azimuth = Radians(ee.Image(az))\n",
-    "  zenith = Radians(ee.Image(ze))\n",
-    "  # Hillshade = cos(Azimuth - Aspect) * sin(Slope) * sin(Zenith) +\n",
-    "  #     cos(Zenith) * cos(Slope)\n",
-    "  return (azimuth.subtract(aspect).cos()\n",
-    "          .multiply(slope.sin())\n",
-    "          .multiply(zenith.sin())\n",
-    "          .add(\n",
-    "              zenith.cos().multiply(slope.cos())))\n",
-    "\n",
-    "terrain = ee.Algorithms.Terrain(ee.Image('srtm90_v4'))\n",
-    "slope_img = Radians(terrain.select('slope'))\n",
-    "aspect_img = Radians(terrain.select('aspect'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "ee_object = Hillshade(0, 60, slope_img, aspect_img)\n",
-    "ee_layer = EarthEngineLayer(ee_object)\n",
-    "view_state = pdk.ViewState(latitude=36.0756, longitude=-111.9987, zoom=7, bearing=0, pitch=30)\n",
+    "view_state = pdk.ViewState(\n",
+    "    latitude=36.15,\n",
+    "    longitude=-111.96,\n",
+    "    zoom=10.5, \n",
+    "    bearing=-66.16,\n",
+    "    pitch=65,\n",
+    "    maxPitch=80)\n",
     "r = pdk.Deck(\n",
     "    layers=[ee_layer], \n",
     "    initial_view_state=view_state\n",

--- a/py/examples/terrain.ipynb
+++ b/py/examples/terrain.ipynb
@@ -126,8 +126,7 @@
     "    image,\n",
     "    terrain,\n",
     "    vis_params,\n",
-    "    id=\"EETerrainLayer\",\n",
-    "    library_url=\"http://localhost:8001/pydeck_layer_module.js\"\n",
+    "    id=\"EETerrainLayer\"\n",
     ")"
    ]
   },

--- a/py/examples/terrain.ipynb
+++ b/py/examples/terrain.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pydeck Earth Engine Introduction\n",
+    "\n",
+    "This is an introduction to using [Pydeck](https://pydeck.gl) and [Deck.gl](https://deck.gl) with [Google Earth Engine](https://earthengine.google.com/) in Jupyter Notebooks.\n",
+    "\n",
+    "To see this example online, view the [JavaScript version][js-example].\n",
+    "\n",
+    "[js-example]: https://earthengine-layers.com/examples/image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run this notebook locally, you'll need to install some dependencies. Installing into a new Conda environment is recommended. To create and enter the environment, make sure you have [Conda installed](https://www.anaconda.com/products/individual), then run:\n",
+    "\n",
+    "```bash\n",
+    "conda create -n pydeck-ee -c conda-forge python jupyter jupyterlab notebook pydeck earthengine-api nodejs -y\n",
+    "conda activate pydeck-ee\n",
+    "\n",
+    "# Install the pydeck-earthengine-layers package from pip\n",
+    "pip install pydeck-earthengine-layers\n",
+    "\n",
+    "# If using Jupyter Notebook:\n",
+    "jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck\n",
+    "jupyter nbextension enable --sys-prefix --py pydeck\n",
+    "\n",
+    "# If using Jupyter Lab\n",
+    "jupyter labextension install @jupyter-widgets/jupyterlab-manager\n",
+    "DECKGL_SEMVER=`python -c \"import pydeck; print(pydeck.frontend_semver.DECKGL_SEMVER)\"`\n",
+    "jupyter labextension install @deck.gl/jupyter-widget@$DECKGL_SEMVER\n",
+    "```\n",
+    "\n",
+    "then open Jupyter Notebook with `jupyter notebook` or Jupyter Lab with `jupyter lab`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now in a Python Jupyter Notebook, let's first import required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydeck_earthengine_layers import EarthEngineTerrainLayer\n",
+    "import pydeck as pdk\n",
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authenticate with Earth Engine\n",
+    "\n",
+    "Using Earth Engine requires authentication. If you don't have a Google account approved for use with Earth Engine, you'll need to request access. For more information and to sign up, go to https://signup.earthengine.google.com/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you haven't used Earth Engine in Python before, the next block will create a prompt which waits for user input. If you don't see a prompt, you may need to authenticate on the command line with `earthengine authenticate` and then restart the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ee.Initialize()\n",
+    "except Exception as e:\n",
+    "    ee.Authenticate()\n",
+    "    ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Elevation data example\n",
+    "\n",
+    "Now let's make a simple example using [Shuttle Radar Topography Mission (SRTM)][srtm] elevation data. Here we create an `ee.Image` object referencing that dataset.\n",
+    "\n",
+    "[srtm]: https://developers.google.com/earth-engine/datasets/catalog/CGIAR_SRTM90_V4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = ee.Image('CGIAR/SRTM90_V4')\n",
+    "terrain = ee.Image('USGS/NED').select('elevation')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here `vis_params` consists of parameters that will be passed to the Earth Engine [`visParams` argument][visparams]. Any parameters that you could pass directly to Earth Engine in the code editor, you can also pass here to the `EarthEngineLayer`.\n",
+    "\n",
+    "[visparams]: https://developers.google.com/earth-engine/image_visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis_params={\n",
+    "    \"min\": 0, \n",
+    "    \"max\": 4000,\n",
+    "    \"palette\": ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5']\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to create the Pydeck layer. The `EarthEngineLayer` makes this simple. Just pass the Earth Engine object to the class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Including the `id` argument isn't necessary when you only have one pydeck layer, but it is necessary to distinguish multiple layers, so it's good to get into the habit of including an `id` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee_layer = EarthEngineTerrainLayer(\n",
+    "    image,\n",
+    "    terrain,\n",
+    "    vis_params,\n",
+    "    id=\"SRTM_layer\",\n",
+    "    library_url=\"http://localhost:8001/pydeck_layer_module.js\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just pass this layer to a `pydeck.Deck` instance, and call `.show()` to create a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "13a4a01c4f9a4d0183749653bbbe3b96",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DeckGLWidget(custom_libraries=[{'libraryName': 'EarthEngineLayerLibrary', 'resourceUri': 'http://localhost:800…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view_state = pdk.ViewState(latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[ee_layer], \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hillshade Example\n",
+    "\n",
+    "As a slightly more in-depth example, let's use the SRTM dataset to calculate hillshading. This example comes from [giswqs/earthengine-py-notebooks][giswqs/earthengine-py-notebooks]:\n",
+    "\n",
+    "[giswqs/earthengine-py-notebooks]: https://github.com/giswqs/earthengine-py-notebooks/blob/master/Visualization/hillshade.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add Earth Engine dataset\n",
+    "import math\n",
+    "\n",
+    "def Radians(img):\n",
+    "  return img.toFloat().multiply(math.pi).divide(180)\n",
+    "\n",
+    "def Hillshade(az, ze, slope, aspect):\n",
+    "  \"\"\"Compute hillshade for the given illumination az, el.\"\"\"\n",
+    "  azimuth = Radians(ee.Image(az))\n",
+    "  zenith = Radians(ee.Image(ze))\n",
+    "  # Hillshade = cos(Azimuth - Aspect) * sin(Slope) * sin(Zenith) +\n",
+    "  #     cos(Zenith) * cos(Slope)\n",
+    "  return (azimuth.subtract(aspect).cos()\n",
+    "          .multiply(slope.sin())\n",
+    "          .multiply(zenith.sin())\n",
+    "          .add(\n",
+    "              zenith.cos().multiply(slope.cos())))\n",
+    "\n",
+    "terrain = ee.Algorithms.Terrain(ee.Image('srtm90_v4'))\n",
+    "slope_img = Radians(terrain.select('slope'))\n",
+    "aspect_img = Radians(terrain.select('aspect'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "ee_object = Hillshade(0, 60, slope_img, aspect_img)\n",
+    "ee_layer = EarthEngineLayer(ee_object)\n",
+    "view_state = pdk.ViewState(latitude=36.0756, longitude=-111.9987, zoom=7, bearing=0, pitch=30)\n",
+    "r = pdk.Deck(\n",
+    "    layers=[ee_layer], \n",
+    "    initial_view_state=view_state\n",
+    ")\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/py/examples/terrain.ipynb
+++ b/py/examples/terrain.ipynb
@@ -17,7 +17,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, import required packages. Note that here we import the `EarthEngineTerrainLayer` instead of the `EarthEngineLayer`, as in other examples."
+    "First, import required packages. Note that here we import the `EarthEngineTerrainLayer` instead of the `EarthEngineLayer`."
    ]
   },
   {
@@ -61,7 +61,7 @@
    "source": [
     "### Terrain Example\n",
     "\n",
-    "In contrast to the `EarthEngineLayer`, where you need to supply _one_ Earth Engine object to render, with the `EarthEngineTerrainLayer` you must supply **two** Earth Engine objects. The first is used to render the image in the same way as the `EarthEngineLayer`; the second supplies elevation values used to extrude terrain in the third dimension. Hence the former can be any `Image` object; the latter must be an `Image` object whose values represents terrain heights.\n",
+    "In contrast to the `EarthEngineLayer`, where you need to supply _one_ Earth Engine object to render, with the `EarthEngineTerrainLayer` you must supply **two** Earth Engine objects. The first is used to render the image in the same way as the `EarthEngineLayer`; the second supplies elevation values used to extrude terrain in 3D. Hence the former can be any `Image` object; the latter must be an `Image` object whose values represents terrain heights.\n",
     "\n",
     "It's important for the terrain source to have relatively high spatial resolution. In previous examples, we used [SRTM90][srtm90] as an elevation source, but that only has a resolution of 90 meters. When used as an elevation source, it looks very blocky/pixelated at high zoom levels. In this example we'll use [SRTM30][srtm30] (30-meter resolution) as the `Image` source and the [USGS's National Elevation Dataset][ned] (10-meter resolution, U.S. only) as the terrain source. SRTM30 is generally the best-resolution worldwide data source available.\n",
     "\n",
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = ee.Image('USGS/SRTMGL1_003').select('elevation')\n",
+    "image = ee.Image('USGS/SRTMGL1_003')\n",
     "terrain = ee.Image('USGS/NED').select('elevation')"
    ]
   },
@@ -126,7 +126,7 @@
     "    image,\n",
     "    terrain,\n",
     "    vis_params,\n",
-    "    id=\"SRTM_layer\",\n",
+    "    id=\"EETerrainLayer\",\n",
     "    library_url=\"http://localhost:8001/pydeck_layer_module.js\"\n",
     ")"
    ]
@@ -149,8 +149,7 @@
     "    longitude=-111.96,\n",
     "    zoom=10.5, \n",
     "    bearing=-66.16,\n",
-    "    pitch=65,\n",
-    "    maxPitch=80)\n",
+    "    pitch=60)\n",
     "r = pdk.Deck(\n",
     "    layers=[ee_layer], \n",
     "    initial_view_state=view_state\n",
@@ -182,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/py/pydeck_earthengine_layers/__init__.py
+++ b/py/pydeck_earthengine_layers/__init__.py
@@ -4,4 +4,5 @@ __author__ = """Kyle Barron"""
 __email__ = 'kyle@unfolded.ai'
 __version__ = '1.0.1'
 
-from .pydeck_earthengine_layers import EarthEngineLayer
+from .pydeck_earthengine_layers import (
+    EarthEngineLayer, EarthEngineTerrainLayer)

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -6,12 +6,14 @@ import ee
 import pydeck as pdk
 import requests
 
-EARTHENGINE_LAYER_BUNDLE_URL = 'https://unpkg.com/@unfolded.gl/earthengine-layers@1.0.0/dist/pydeck_layer_module.min.js'
+EARTHENGINE_LAYER_BUNDLE_URL = 'https://unpkg.com/@unfolded.gl/earthengine-layers@1.1.1/dist/pydeck_layer_module.min.js'
 
 
 class EarthEngineLayer(pdk.Layer):
-    """Wrapper class for using the Earth Engine custom layer with Pydeck
+    """Wrapper class for using the EarthEngineLayer with Pydeck
     """
+    layer_name = 'EarthEngineLayer'
+
     def __init__(
             self,
             ee_object,
@@ -30,7 +32,7 @@ class EarthEngineLayer(pdk.Layer):
               bundle
         """
         super(EarthEngineLayer, self).__init__(
-            'EarthEngineLayer', None, vis_params=vis_params, **kwargs)
+            self.layer_name, None, vis_params=vis_params, **kwargs)
 
         # Should we assume ee has already been initialized?
         ee.Initialize()
@@ -105,3 +107,25 @@ class EarthEngineLayer(pdk.Layer):
 
         self._refresh_token()
         return self.access_token
+
+
+class EarthEngineTerrainLayer(EarthEngineLayer):
+    """Wrapper class for using the EarthEngineTerrainLayer with Pydeck
+    """
+    layer_name = 'EarthEngineTerrainLayer'
+
+    def __init__(
+            self,
+            ee_object,
+            ee_terrain_object,
+            vis_params=None,
+            credentials=None,
+            library_url=EARTHENGINE_LAYER_BUNDLE_URL,
+            **kwargs):
+        super(EarthEngineTerrainLayer, self).__init__(
+            ee_object=ee_object,
+            ee_terrain_object=ee_terrain_object,
+            vis_params=vis_params,
+            credentials=credentials,
+            library_url=library_url,
+            **kwargs)

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -18,6 +18,7 @@ class EarthEngineLayer(pdk.Layer):
             self,
             ee_object,
             vis_params=None,
+            *,
             credentials=None,
             library_url=EARTHENGINE_LAYER_BUNDLE_URL,
             **kwargs):
@@ -119,6 +120,7 @@ class EarthEngineTerrainLayer(EarthEngineLayer):
             ee_object,
             ee_terrain_object,
             vis_params=None,
+            *,
             credentials=None,
             library_url=EARTHENGINE_LAYER_BUNDLE_URL,
             **kwargs):
@@ -129,3 +131,6 @@ class EarthEngineTerrainLayer(EarthEngineLayer):
             credentials=credentials,
             library_url=library_url,
             **kwargs)
+
+        self.ee_terrain_object = ee_terrain_object.serialize(
+        ) if not isinstance(ee_terrain_object, str) else ee_terrain_object

--- a/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
+++ b/py/pydeck_earthengine_layers/pydeck_earthengine_layers.py
@@ -6,7 +6,7 @@ import ee
 import pydeck as pdk
 import requests
 
-EARTHENGINE_LAYER_BUNDLE_URL = 'https://unpkg.com/@unfolded.gl/earthengine-layers@1.1.1/dist/pydeck_layer_module.min.js'
+EARTHENGINE_LAYER_BUNDLE_URL = 'https://unpkg.com/@unfolded.gl/earthengine-layers@1.2.0/dist/pydeck_layer_module.min.js'
 
 
 class EarthEngineLayer(pdk.Layer):

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -15,6 +15,9 @@ universal = 1
 [flake8]
 exclude = docs
 
+[isort]
+multi_line_output=4
+
 [aliases]
 test = pytest
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,18 +2243,18 @@
     probe.gl "3.3.0"
     puppeteer "^1.16.0"
 
-"@rollup/plugin-commonjs@^11.0.2":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz#60636c7a722f54b41e419e1709df05c7234557ef"
-  integrity sha512-Ycr12N3ZPN96Fw2STurD21jMqzKwL9QuFhms3SD7KKRK7oaXUsBU9Zt0jL/rOPHiPYisI21/rXGO3jr9BnLHUA==
+"@rollup/plugin-commonjs@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-15.0.0.tgz#690d15a9d54ba829db93555bff9b98ff34e08574"
+  integrity sha512-8uAdikHqVyrT32w1zB9VhW6uGwGjhKgnDNP4pQJsjdnyF4FgCj6/bmv24c7v2CuKhq32CcyCwRzMPEElaKkn0w==
   dependencies:
-    "@rollup/pluginutils" "^3.0.8"
+    "@rollup/pluginutils" "^3.1.0"
     commondir "^1.0.1"
-    estree-walker "^1.0.1"
-    glob "^7.1.2"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
 
 "@rollup/plugin-json@^4.0.2":
   version "4.1.0"
@@ -2274,7 +2274,7 @@
     is-module "^1.0.0"
     resolve "^1.14.2"
 
-"@rollup/pluginutils@^3.0.8":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -5082,6 +5082,11 @@ estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
+estree-walker@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
+  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5807,7 +5812,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -6768,7 +6773,7 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
-is-reference@^1.1.2:
+is-reference@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
   integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
@@ -7377,7 +7382,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
   integrity sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==
 
-magic-string@^0.25.2:
+magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -9629,7 +9634,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.17.0:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
Closes #90

Adds the ability to call the EarthEngineTerrainLayer from Python.

- Updates `rollup/plugin-commonjs` to fix some bundling issues with dependencies
- Removes `@luma.gl` from rollup externals. Since we never call luma ourselves anywhere in EarthEngine layer, declaring it as external hid the bundled copy of luma.gl within `deck.gl/geo-layers`
- Adds more `@deck.gl` externals. Full list derived from `jupyter-widget` [here](https://github.com/visgl/deck.gl/blob/c8702ae134e0598b2fdca03642744f25e9de593b/modules/jupyter-widget/src/deck-bundle.js). Otherwise had multiple copies of deck.gl bundled, which caused "Model needs a Program" errors
- [x] Notebook example of the `EarthEngineTerrainLayer`

Questions:

- [x] what externals should be declared for the non-Pydeck EE bundle? Should we assume that all deck.gl modules are loaded separately?