### PR TITLE
Forward added TileLayer props in 8.2

### DIFF
--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -30,7 +30,10 @@ const defaultProps = {
   animate: false,
   // Frames per second
   animationSpeed: 12,
-  refinementStrategy: 'no-overlap'
+
+  // TileLayer props with custom defaults
+  refinementStrategy: 'no-overlap',
+  tileSize: 256
 };
 
 export default class EarthEngineLayer extends CompositeLayer {
@@ -268,14 +271,17 @@ export default class EarthEngineLayer extends CompositeLayer {
   renderLayers() {
     const {mapid, frame = 0, renderMethod} = this.state;
     const {
-      refinementStrategy,
-      onViewportLoad,
-      onTileLoad,
-      onTileError,
+      extent,
+      maxCacheByteSize,
+      maxCacheSize,
+      maxRequests,
       maxZoom,
       minZoom,
-      maxCacheSize,
-      maxCacheByteSize
+      onTileError,
+      onTileLoad,
+      onViewportLoad,
+      refinementStrategy,
+      tileSize
     } = this.props;
 
     return (
@@ -287,15 +293,18 @@ export default class EarthEngineLayer extends CompositeLayer {
               id: mapid
             }),
             {
-              refinementStrategy,
-              onViewportLoad,
-              onTileLoad,
-              onTileError,
+              extent,
+              frame,
+              maxCacheByteSize,
+              maxCacheSize,
+              maxRequests,
               maxZoom,
               minZoom,
-              maxCacheSize,
-              maxCacheByteSize,
-              frame,
+              onTileError,
+              onTileLoad,
+              onViewportLoad,
+              refinementStrategy,
+              tileSize,
 
               getTileData: options => this.getTileData(options),
 

--- a/modules/earthengine-layers/src/earth-engine-terrain-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-terrain-layer.js
@@ -1,5 +1,5 @@
 import {CompositeLayer} from '@deck.gl/core';
-import {TileLayer, TerrainLayer} from '@deck.gl/geo-layers';
+import {TerrainLayer} from '@deck.gl/geo-layers';
 import ee from '@google/earthengine';
 import {initializeEEApi} from './ee-api'; // Promisify ee apis
 import {deepEqual, promisifyEEMethod} from './utils';
@@ -19,16 +19,18 @@ export const ELEVATION_DECODER = {
 let accessToken;
 
 const defaultProps = {
-  ...TileLayer.defaultProps,
-  // Set lower default than in deck.gl TileLayer
-  maxRequests: 6,
+  ...TerrainLayer.defaultProps,
   // data prop is unused
   data: {type: 'object', value: null},
   token: {type: 'string', value: null},
   eeObject: {type: 'object', value: null},
   eeTerrainObject: {type: 'object', value: null},
   visParams: {type: 'object', value: null, equal: deepEqual},
-  refinementStrategy: 'no-overlap'
+
+  // TileLayer props with custom defaults
+  maxRequests: 6,
+  refinementStrategy: 'no-overlap',
+  tileSize: 256
 };
 
 export default class EarthEngineTerrainLayer extends CompositeLayer {
@@ -138,6 +140,7 @@ export default class EarthEngineTerrainLayer extends CompositeLayer {
 
   renderLayers() {
     const {mapid, urlFormat, meshMapid, meshUrlFormat} = this.state;
+    const {extent, maxRequests, maxZoom, minZoom, tileSize} = this.props;
 
     return (
       mapid &&
@@ -150,7 +153,12 @@ export default class EarthEngineTerrainLayer extends CompositeLayer {
           elevationData: meshUrlFormat,
           texture: urlFormat,
           elevationDecoder: ELEVATION_DECODER,
-          meshMaxError: 10
+          meshMaxError: 10,
+          extent,
+          maxRequests,
+          maxZoom,
+          minZoom,
+          tileSize
         }
       )
     );


### PR DESCRIPTION
- Forwards additional props that are new in TileLayer 8.2
- Sets `tileSize` to 256 by default, since PNGs returned from Earth Engine are 256x256px. This renders at higher resolution on hi-dpi displays. The RequestScheduler is still in effect.