### PR TITLE
Check environment variables are set before building site

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,8 +8,9 @@
   ],
   "main": "gatsby-config.js",
   "scripts": {
+    "check-env-var": "if [[ -z $GoogleMapsAPIKey ]]; then exit 1; fi; if [[ -z $EE_CLIENT_ID ]]; then exit 1; fi;",
     "start": "yarn clean && yarn develop",
-    "build": "yarn clean-examples && yarn clean && gatsby build --no-uglify",
+    "build": "yarn check-env-var && yarn clean-examples && yarn clean && gatsby build --no-uglify",
     "clean": "rm -rf ./.cache ./public",
     "clean-examples": "find ../examples -name node_modules -exec rm -rf {} \\; || true",
     "develop": "yarn clean-examples && gatsby develop --port 8080",

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "gatsby-config.js",
   "scripts": {
-    "check-env-var": "if [[ -z $GoogleMapsAPIKey ]]; then exit 1; fi; if [[ -z $EE_CLIENT_ID ]]; then exit 1; fi;",
+    "check-env-var": "if [[ -z $GoogleMapsAPIKey ]]; then echo 'Missing GoogleMapsAPIKey environment variable' && exit 1; fi; if [[ -z $EE_CLIENT_ID ]]; then echo 'Missing EE_CLIENT_ID environment variable' && exit 1; fi;",
     "start": "yarn clean && yarn develop",
     "build": "yarn check-env-var && yarn clean-examples && yarn clean && gatsby build --no-uglify",
     "clean": "rm -rf ./.cache ./public",


### PR DESCRIPTION
The last time I deployed `earthengine-layers.com` I accidentally forgot to include the Google Maps API Key. This change means that running `yarn build && yarn deploy` will fail if the `EE_CLIENT_ID` and `GoogleMapsAPIKey` aren't set.