### PR TITLE
Use lodash._isEqual for checking eeObject equality

### DIFF
--- a/modules/earthengine-layers/package.json
+++ b/modules/earthengine-layers/package.json
@@ -19,7 +19,8 @@
     "@loaders.gl/core": "2.3.0-alpha.10",
     "@loaders.gl/images": "2.3.0-alpha.10",
     "@loaders.gl/json": "2.3.0-alpha.10",
-    "@math.gl/web-mercator": "3.1.2"
+    "@math.gl/web-mercator": "3.1.2",
+    "lodash.isequal": "^4.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/modules/earthengine-layers/src/earth-engine-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-layer.js
@@ -6,8 +6,9 @@ import {initializeEEApi} from './ee-api'; // Promisify ee apis
 import ee from '@google/earthengine';
 import {load} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
-import {deepEqual, promisifyEEMethod} from './utils';
+import {promisifyEEMethod} from './utils';
 import {JSONLoader} from '@loaders.gl/json';
+import isDeepEqual from 'lodash.isequal';
 
 // Global access token, to allow single EE API initialization if using multiple
 // layers
@@ -20,12 +21,12 @@ const defaultProps = {
   data: {type: 'object', value: null},
   token: {type: 'string', value: null},
   eeObject: {type: 'object', value: null},
-  visParams: {type: 'object', value: null, equal: deepEqual},
+  visParams: {type: 'object', value: null, equal: isDeepEqual},
   // Force rendering as vector
   asVector: false,
   // When rendered as vector, selectors that should be used to determine which
   // attributes will be downloaded
-  selectors: {type: 'array', value: [], equal: deepEqual},
+  selectors: {type: 'array', value: [], equal: isDeepEqual},
   // Force animation; animation is on by default when ImageCollection passed
   animate: false,
   // Frames per second
@@ -82,7 +83,7 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   _updateEEObject(props, oldProps, changeFlags) {
-    if (props.eeObject === oldProps.eeObject) {
+    if (isDeepEqual(props.eeObject, oldProps.eeObject)) {
       return;
     }
 
@@ -109,7 +110,10 @@ export default class EarthEngineLayer extends CompositeLayer {
   }
 
   async _updateEEVisParams(props, oldProps, changeFlags) {
-    if (props.visParams === oldProps.visParams && props.eeObject === oldProps.eeObject) {
+    if (
+      isDeepEqual(props.visParams, oldProps.visParams) &&
+      isDeepEqual(props.eeObject, oldProps.eeObject)
+    ) {
       return;
     }
     const {animate, asVector, selectors} = props;

--- a/modules/earthengine-layers/src/earth-engine-terrain-layer.js
+++ b/modules/earthengine-layers/src/earth-engine-terrain-layer.js
@@ -2,7 +2,8 @@ import {CompositeLayer} from '@deck.gl/core';
 import {TerrainLayer} from '@deck.gl/geo-layers';
 import ee from '@google/earthengine';
 import {initializeEEApi} from './ee-api'; // Promisify ee apis
-import {deepEqual, promisifyEEMethod} from './utils';
+import {promisifyEEMethod} from './utils';
+import isDeepEqual from 'lodash.isequal';
 
 /**
  * Decoder for Terrarium encoding
@@ -25,7 +26,7 @@ const defaultProps = {
   token: {type: 'string', value: null},
   eeObject: {type: 'object', value: null},
   eeTerrainObject: {type: 'object', value: null},
-  visParams: {type: 'object', value: null, equal: deepEqual},
+  visParams: {type: 'object', value: null, equal: isDeepEqual},
 
   // TileLayer props with custom defaults
   maxRequests: 6,
@@ -62,8 +63,8 @@ export default class EarthEngineTerrainLayer extends CompositeLayer {
 
   _updateEEObject(props, oldProps, changeFlags) {
     if (
-      props.eeObject === oldProps.eeObject &&
-      props.eeTerrainObject === oldProps.eeTerrainObject
+      isDeepEqual(props.eeObject, oldProps.eeObject) &&
+      isDeepEqual(props.eeTerrainObject, oldProps.eeTerrainObject)
     ) {
       return;
     }
@@ -104,9 +105,9 @@ export default class EarthEngineTerrainLayer extends CompositeLayer {
 
   async _updateEEVisParams(props, oldProps, changeFlags) {
     if (
-      props.visParams === oldProps.visParams &&
-      props.eeObject === oldProps.eeObject &&
-      props.eeTerrainObject === oldProps.eeTerrainObject
+      isDeepEqual(props.visParams, oldProps.visParams) &&
+      isDeepEqual(props.eeObject, oldProps.eeObject) &&
+      isDeepEqual(props.eeTerrainObject, oldProps.eeTerrainObject)
     ) {
       return;
     }

--- a/modules/earthengine-layers/src/utils.js
+++ b/modules/earthengine-layers/src/utils.js
@@ -1,25 +1,3 @@
-// From https://github.com/visgl/deck.gl/blob/c66e3e5bca63b6e214c27259025947dcfa7e359a/modules/core/src/utils/deep-equal.js
-// Partial deep equal (only recursive on arrays)
-export function deepEqual(a, b) {
-  if (a === b) {
-    return true;
-  }
-  if (!a || !b) {
-    return false;
-  }
-  for (const key in a) {
-    const aValue = a[key];
-    const bValue = b[key];
-    const equals =
-      aValue === bValue ||
-      (Array.isArray(aValue) && Array.isArray(bValue) && deepEqual(aValue, bValue));
-    if (!equals) {
-      return false;
-    }
-  }
-  return true;
-}
-
 // Promisify eeObject methods
 export function promisifyEEMethod(eeObject, method, ...args) {
   return new Promise((resolve, reject) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,13 +1812,29 @@
     "@math.gl/geospatial" "^3.2.0"
     "@probe.gl/stats" "^3.3.0"
 
-"@loaders.gl/core@2.2.8", "@loaders.gl/core@2.3.0-alpha.10", "@loaders.gl/core@2.3.0-alpha.12", "@loaders.gl/core@^2.2.3":
-  version "2.3.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.3.0-alpha.12.tgz#6bf8a73763f2cf0fb909322e0f6c613889b13954"
-  integrity sha512-+sPIIqjis+fITtH+Nr7R1uJkGoNYiMnjPRsmq0ky/UE69fFP9onF2vI69o/u651Ho/5yzN8tiYQoikZANZx2pQ==
+"@loaders.gl/core@2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.2.8.tgz#fb2060f3b90d3babe0de2a128fc5227f921c08ad"
+  integrity sha512-PM74zQA6Kn6NJCMoRdEDENy9jQWQyMkICKZ6o8UGa6/oi3dD4LO5GhFZSwU6W/Lxl/IeUwaZBQ3MqfT3aXA0Dg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "2.3.0-alpha.12"
+    "@loaders.gl/loader-utils" "2.2.8"
+
+"@loaders.gl/core@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.3.0-alpha.10.tgz#bd58888c85c424dde136c7f798440c8f5b597be8"
+  integrity sha512-rkuO0CxzIjJv52AVEhkDNdh9Xm9tyyZs15agM8rYPsV7ScgeBECVlM5tE702SwbwGsZvPBFHK5mqp2c8zuaLlg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
+
+"@loaders.gl/core@^2.2.3":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.3.11.tgz#231c335f4123f645d4ae369a225f2cddf061135e"
+  integrity sha512-3lmoLy/JiSZQV7oTFcfNrYYonXghEBeEJFK0DHa/AinWVw7Ikz/MK2r3Z4MXElE/tnXPYN/AeLqkfDdwG8Nk1g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@loaders.gl/loader-utils" "2.3.11"
 
 "@loaders.gl/draco@2.2.8":
   version "2.2.8"
@@ -1829,12 +1845,12 @@
     "@loaders.gl/loader-utils" "2.2.8"
     draco3d "^1.3.4"
 
-"@loaders.gl/gis@2.3.0-alpha.12":
-  version "2.3.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-2.3.0-alpha.12.tgz#0d2984f667f0dc7ff3ae2162b79e2fdd17993c72"
-  integrity sha512-RzFFz/yfYFvEJktLZ9/qSuQvEupffm3FntaQJmctWwEdLgj8fSeAmXflKR1EjN9a8EFG2Mr6UfuQh7Zn62HQfQ==
+"@loaders.gl/gis@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-2.3.0-alpha.10.tgz#ef9bfed3fa93ae751b6c6a1966660cc3f7435f21"
+  integrity sha512-jEMa8lC/Nem7r6woS/LO8quoDc+iGHmFZ/6F16Vt4+B+HLtpoLM0BzUpb6qIlprvdcDb7Az2+25Wjn91NzheRg==
   dependencies:
-    "@loaders.gl/loader-utils" "2.3.0-alpha.12"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
@@ -1848,26 +1864,56 @@
     "@loaders.gl/images" "2.2.8"
     "@loaders.gl/loader-utils" "2.2.8"
 
-"@loaders.gl/images@2.2.8", "@loaders.gl/images@2.3.0-alpha.10", "@loaders.gl/images@2.3.0-alpha.12", "@loaders.gl/images@^2.2.3":
-  version "2.3.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.3.0-alpha.12.tgz#b971c64a73cbc0f80d09631249125668a053667b"
-  integrity sha512-H2VON9Ip9npGyuNlJFF+DnjXcIVpQVP8vqzQ0FOheaxxtlwht8lQSsQx7xrRXonw3BJTazZb8W4UbFfX21pqeg==
+"@loaders.gl/images@2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.2.8.tgz#7db7781fcc3aa60f3cf1109370ea87ac5bf78ad0"
+  integrity sha512-qFKdtD8Wo7wmqFJsaqBm5owrzl2vDMlTYzGaqnpNjqVCEmjp8f6mj+511FyXmE4vuPqiC/zOFg/pAKXi39bHRQ==
   dependencies:
-    "@loaders.gl/loader-utils" "2.3.0-alpha.12"
+    "@loaders.gl/loader-utils" "2.2.8"
 
-"@loaders.gl/json@2.3.0-alpha.10", "@loaders.gl/json@2.3.0-alpha.12":
-  version "2.3.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/json/-/json-2.3.0-alpha.12.tgz#31a5c2c837e0dcae7d35dde694bccf894a4c50af"
-  integrity sha512-TVFlfS9AzG5vjoR+XHYww0UTf3CiPthGDd1Xxmb2DKA1SRyMU75iTUMY6o7ieIYO3iCEeg4MRn5KANJj5XSKfg==
+"@loaders.gl/images@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.3.0-alpha.10.tgz#abebdb5fde927cd6e96f9da782a7dd55525f0bc4"
+  integrity sha512-iP7o7ZBO7RhsMHinsiHFeovnx0RzzXqf/4DeWGKDkuSZ6gbqXXtMVnh0HlNg84Jv50iyi7D1gZAIKi2DoqkmrQ==
   dependencies:
-    "@loaders.gl/gis" "2.3.0-alpha.12"
-    "@loaders.gl/loader-utils" "2.3.0-alpha.12"
-    "@loaders.gl/tables" "2.3.0-alpha.12"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
 
-"@loaders.gl/loader-utils@2.2.8", "@loaders.gl/loader-utils@2.3.0-alpha.12", "@loaders.gl/loader-utils@^2.2.3":
-  version "2.3.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.3.0-alpha.12.tgz#eeff03001fe5849572d1cd5d5863bbb4680a5140"
-  integrity sha512-mQEdy89K7XC1vNv6L+5EcqqtokqFTfXtuxrtz6PRHlTY2wb3QSkiNNu30HFJWtJyWdJKLAEgXY0J9/2s105yDQ==
+"@loaders.gl/images@^2.2.3":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.3.11.tgz#3bfca6124de071d4545a81fb502d1180d84a8801"
+  integrity sha512-Kb2lQZQgOTh/DMbWQmkMfsilyQamSJqDTZDoJKbXM6x3P+O9cLuMZXE6KQrq80z5Ax1BcC7nGcn+hNq5904ADA==
+  dependencies:
+    "@loaders.gl/loader-utils" "2.3.11"
+
+"@loaders.gl/json@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/json/-/json-2.3.0-alpha.10.tgz#907b9cc7847aeda74a1d8b7a9addb89b9272e543"
+  integrity sha512-O5XyXJnNKQH6PGtH6eJCwLTr783hARtmRaWP4EVwB3eqBMROW9fD5KyEdjmiQafqP8YAE4uOGymzuEMvq8VvKQ==
+  dependencies:
+    "@loaders.gl/gis" "2.3.0-alpha.10"
+    "@loaders.gl/loader-utils" "2.3.0-alpha.10"
+    "@loaders.gl/tables" "2.3.0-alpha.10"
+
+"@loaders.gl/loader-utils@2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.2.8.tgz#9f12f3460260b15e961fa46c3d3c867d7bf48bee"
+  integrity sha512-3F2VgxJPxjuZwAr8fDBkZzx3Wg275XdVaWnyYQ3uyZQ22yGEkrzKc+TlgcqSrxbO5pHrtS5PdS7dmyoJo2+Bdg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@probe.gl/stats" "^3.3.0"
+
+"@loaders.gl/loader-utils@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.3.0-alpha.10.tgz#b5639e2ae50e827ff552fefe5589f19f2e18f4f0"
+  integrity sha512-+wn7TwLtzDt25OJT+Qc5ZIcBnhuSh76b8HELVsg/XVPC/A+2YcFKD8yKQdCpASvHprcdz7+iwhypZm9HpNTjiQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@probe.gl/stats" "^3.3.0"
+
+"@loaders.gl/loader-utils@2.3.11", "@loaders.gl/loader-utils@^2.2.3":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.3.11.tgz#1f7e8db6f464daacfdc39c0ed6872f232da67423"
+  integrity sha512-PE9dhBdw/GuH7ZHrVkhy9wdCTXJ7/nvMhMjL91E0bJ206TvPO+vGDMtIu9QFqt254PE5oU35MJS5bbB/Bgs5kQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@probe.gl/stats" "^3.3.0"
@@ -1890,13 +1936,12 @@
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
-"@loaders.gl/tables@2.3.0-alpha.12":
-  version "2.3.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.3.0-alpha.12.tgz#5ffe658ff55adf835dacb2d2c87b1e234762fc19"
-  integrity sha512-a+RVZr7LeJCxZepbSH/X3G1XPkBL5leWTKfGpyie7k8q+rzMFzME30ZRFvW4b5vC1eRynyZyWkTLm7sNuBeEjg==
+"@loaders.gl/tables@2.3.0-alpha.10":
+  version "2.3.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.3.0-alpha.10.tgz#963854466f4ec11854f54c686a2992d3ec77dde5"
+  integrity sha512-DFVBvSYJh40yie+zjJqS3cyZVK1FOJ07trcMe/Unj3RDfFwCHPIbm0OiXmeTVZR7GoPeX67zpgJS5sggCGuP5g==
   dependencies:
-    "@loaders.gl/core" "2.3.0-alpha.12"
-    d3-dsv "^1.2.0"
+    "@loaders.gl/core" "2.3.0-alpha.10"
 
 "@loaders.gl/terrain@^2.2.3":
   version "2.2.8"
@@ -3877,15 +3922,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.18.0, commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
+commander@^2.18.0, commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.1:
   version "4.1.1"
@@ -4277,15 +4322,6 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
-
-d3-dsv@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
-  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
-  dependencies:
-    commander "2"
-    iconv-lite "0.4"
-    rw "1"
 
 dargs@^4.0.1:
   version "4.1.0"
@@ -6349,7 +6385,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7296,6 +7332,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -9748,7 +9789,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rw@1, rw@^1.3.3:
+rw@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=


### PR DESCRIPTION
Currently we use `===` for checking if EE objects are identical. EE objects are a sort of JS object under the hood. This means that this is true:

```js
const eeObject = ee.Image('CGIAR/SRTM90_V4');
eeObject === eeObject // true
```

but this isn't:
```
ee.Image('CGIAR/SRTM90_V4') === ee.Image('CGIAR/SRTM90_V4');
// false
```

This PR uses `lodash.isEqual` for checking deep equality of EE objects. This prevents unnecessarily creating new map objects when the referenced dataset is the same.